### PR TITLE
Add apt update to github workflow

### DIFF
--- a/.github/workflows/.github.yml
+++ b/.github/workflows/.github.yml
@@ -43,6 +43,7 @@ jobs:
     - name: Install steam runtime
       if: startsWith(matrix.os, 'ubuntu')
       run: |
+        sudo apt update
         ./steam-runtime/setup_chroot.sh --i386 --tarball ./com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
         sudo sed -i 's/groups=sudo/groups=adm/g' /etc/schroot/chroot.d/steamrt_scout_i386.conf
 


### PR DESCRIPTION
Recently I've got the error in github action
```Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/d/debootstrap/debootstrap_1.0.118ubuntu1.4_all.deb  404  Not Found```
Deboostrap is needed by steam runtime setup.
I guess we need `apt update` before that.