### PR TITLE
Fixes #200

### DIFF
--- a/dlls/scripted.cpp
+++ b/dlls/scripted.cpp
@@ -370,6 +370,9 @@ void CCineMonster::PossessEntity( void )
 			if( FStrEq( STRING( m_iszIdle ), STRING( m_iszPlay ) ) )
 			{
 				pTarget->pev->framerate = 0;
+			} else if ( m_fMoveTo == 4 && !m_iszPlay ) // Nothing else to do, so start an empty sequence so that the sequence completions can be fired off.
+			{
+				StartSequence( pTarget, 0, TRUE );
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #200

If a scripted sequence is a teleport and has neither an idle animation to play nor an action to perform, then perform an empty sequence so that it may immediately close, allowing the scripted_sequence to fire to its targets and freeing the NPC from being locked in perpetual MONSTERSTATE_SCRIPT.