### PR TITLE
Support cmake older than 3.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@
 
 cmake_minimum_required(VERSION 2.8.12)
 
-if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.15.0")
-    cmake_policy(SET CMP0091 NEW)
+if(NOT ${CMAKE_VERSION} VERSION_LESS "3.15.0")
+	cmake_policy(SET CMP0091 NEW)
 endif()
 
 # Install custom module path


### PR DESCRIPTION
VERSION_GREATER_EQUAL was introduced in cmake 3.7. Using NOT VERSION_LESS in order to support older cmake versions.