### PR TITLE
Fix deploy animations on fast weapon switching

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -3095,7 +3095,15 @@ void CBasePlayer::SelectItem( const char *pstr )
 
 	if( m_pActiveItem )
 	{
+		CBasePlayerWeapon* weapon = (CBasePlayerWeapon*)(m_pActiveItem->GetWeaponPtr());
+		if (weapon)
+			weapon->m_ForceSendAnimations = true;
+
 		m_pActiveItem->Deploy();
+
+		if (weapon)
+			weapon->m_ForceSendAnimations = false;
+
 		m_pActiveItem->UpdateItemInfo();
 	}
 }
@@ -3121,7 +3129,16 @@ void CBasePlayer::SelectLastItem( void )
 	CBasePlayerItem *pTemp = m_pActiveItem;
 	m_pActiveItem = m_pLastItem;
 	m_pLastItem = pTemp;
+
+	CBasePlayerWeapon* weapon = (CBasePlayerWeapon*)(m_pActiveItem->GetWeaponPtr());
+	if (weapon)
+		weapon->m_ForceSendAnimations = true;
+
 	m_pActiveItem->Deploy();
+
+	if (weapon)
+		weapon->m_ForceSendAnimations = false;
+
 	m_pActiveItem->UpdateItemInfo();
 }
 

--- a/dlls/weapons.cpp
+++ b/dlls/weapons.cpp
@@ -820,7 +820,7 @@ int CBasePlayerWeapon::UpdateClientData( CBasePlayer *pPlayer )
 void CBasePlayerWeapon::SendWeaponAnim( int iAnim, int skiplocal, int body )
 {
 	if( UseDecrement() )
-		skiplocal = 1;
+		skiplocal = !m_ForceSendAnimations;
 	else
 		skiplocal = 0;
 

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -351,6 +351,9 @@ public:
 	// hle time creep vars
 	float	m_flPrevPrimaryAttack;
 	float	m_flLastFireTime;
+
+	//Hack so deploy animations work when weapon prediction is enabled.
+	bool m_ForceSendAnimations;
 };
 
 class CBasePlayerAmmo : public CBaseEntity


### PR DESCRIPTION
Sometimes weapon deploy animation does not play if previous and next weapons deploy animations have the same sequence index (e.g. gauss and crossbow).

Same as https://github.com/SamVanheer/halflife-updated/commit/42f45bdaec7c110424eec4a5e6664d14dcd0e6e1 but with hacks to fix fast switch by selecting weapon via keybinds (the original fix only applies to fast switching via Last Weapon bind).