### PR TITLE
Fix client event angles

### DIFF
--- a/cl_dll/com_weapons.cpp
+++ b/cl_dll/com_weapons.cpp
@@ -137,7 +137,7 @@ void HUD_PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short event
 
 	// Weapon prediction events are assumed to occur at the player's origin
 	org			= g_finalstate->playerstate.origin;
-	ang			= v_angles;
+	ang			= v_client_aimangles;
 	gEngfuncs.pfnPlaybackEvent( flags, pInvoker, eventindex, delay, org, ang, fparam1, fparam2, iparam1, iparam2, bparam1, bparam2 );
 }
 

--- a/cl_dll/com_weapons.h
+++ b/cl_dll/com_weapons.h
@@ -39,6 +39,7 @@ extern cvar_t *cl_lw;
 
 extern int g_runfuncs;
 extern vec3_t v_angles;
+extern vec3_t v_client_aimangles;
 extern float g_lastFOV;
 extern struct local_state_s *g_finalstate;
 #endif

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -88,6 +88,7 @@ float v_cameraFocusAngle = 35.0f;
 int v_cameraMode = CAM_MODE_FOCUS;
 qboolean v_resetCamera = 1;
 
+vec3_t v_client_aimangles;
 vec3_t g_ev_punchangle;
 
 cvar_t	*scr_ofsx;
@@ -724,6 +725,7 @@ void V_CalcNormalRefdef( struct ref_params_s *pparams )
 
 	// Store off v_angles before munging for third person
 	v_angles = pparams->viewangles;
+	v_client_aimangles = pparams->cl_viewangles;
 	v_lastAngles = pparams->viewangles;
 	//v_cl_angles = pparams->cl_viewangles;	// keep old user mouse angles !
 	if( CL_IsThirdPerson() )


### PR DESCRIPTION
Same as https://github.com/ValveSoftware/halflife/issues/1744
Note that it affects not only trigger_camera, but the angle used in events in general