### PR TITLE
[hlfixed] Restore room sound type

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -124,9 +124,9 @@ TYPEDESCRIPTION	CBasePlayer::m_playerSaveData[] =
 	//DEFINE_FIELD( CBasePlayer, m_flStopExtraSoundTime, FIELD_TIME ),
 	//DEFINE_FIELD( CBasePlayer, m_fKnownItem, FIELD_INTEGER ), // reset to zero on load
 	//DEFINE_FIELD( CBasePlayer, m_iPlayerSound, FIELD_INTEGER ),	// Don't restore, set in Precache()
-	//DEFINE_FIELD( CBasePlayer, m_pentSndLast, FIELD_EDICT ),	// Don't restore, client needs reset
-	//DEFINE_FIELD( CBasePlayer, m_flSndRoomtype, FIELD_FLOAT ),	// Don't restore, client needs reset
-	//DEFINE_FIELD( CBasePlayer, m_flSndRange, FIELD_FLOAT ),	// Don't restore, client needs reset
+	DEFINE_FIELD( CBasePlayer, m_pentSndLast, FIELD_EDICT ),
+	DEFINE_FIELD( CBasePlayer, m_SndRoomtype, FIELD_INTEGER ),
+	DEFINE_FIELD( CBasePlayer, m_flSndRange, FIELD_FLOAT ),
 	//DEFINE_FIELD( CBasePlayer, m_fNewAmmo, FIELD_INTEGER ), // Don't restore, client needs reset
 	//DEFINE_FIELD( CBasePlayer, m_flgeigerRange, FIELD_FLOAT ),	// Don't restore, reset in Precache()
 	//DEFINE_FIELD( CBasePlayer, m_flgeigerDelay, FIELD_FLOAT ),	// Don't restore, reset in Precache()
@@ -2818,6 +2818,7 @@ void CBasePlayer::Spawn( void )
 
 	pev->fov = m_iFOV = 0;// init field of view.
 	m_iClientFOV = -1; // make sure fov reset is sent
+	m_ClientSndRoomtype = -1;
 
 	m_flNextDecalTime = 0;// let this player decal as soon as he spawns.
 
@@ -2967,6 +2968,8 @@ int CBasePlayer::Restore( CRestore &restore )
 	pev->angles = pev->v_angle;
 
 	pev->fixangle = TRUE;           // turn this way immediately
+
+	m_ClientSndRoomtype = -1;
 
 	// Copied from spawn() for now
 	m_bloodColor = BLOOD_COLOR_RED;
@@ -3353,13 +3356,13 @@ void CBasePlayer::ForceClientDllUpdate( void )
 	m_iClientBattery = -1;
 	m_iClientHideHUD = -1;	// Vit_amiN: forcing to update
 	m_iClientFOV = -1;	// Vit_amiN: force client weapons to be sent
+	m_ClientSndRoomtype = -1;
 	m_iTrain |= TRAIN_NEW;  // Force new train message.
 	m_fWeapon = FALSE;          // Force weapon send
 	m_fKnownItem = FALSE;    // Force weaponinit messages.
 	m_fInitHUD = TRUE;		// Force HUD gmsgResetHUD message
 	m_bSentBhopcap = true; // a1ba: Update bhopcap state
 	memset( m_rgAmmoLast, 0, sizeof( m_rgAmmoLast )); // a1ba: Force update AmmoX
-
 
 
 	// Now force all the necessary messages
@@ -4123,6 +4126,16 @@ void CBasePlayer::UpdateClientData( void )
 	{
 		UpdateStatusBar();
 		m_flNextSBarUpdateTime = gpGlobals->time + 0.2f;
+	}
+
+	// Send new room type to client.
+	if (m_ClientSndRoomtype != m_SndRoomtype)
+	{
+		m_ClientSndRoomtype = m_SndRoomtype;
+
+		MESSAGE_BEGIN(MSG_ONE, SVC_ROOMTYPE, NULL, edict());
+		WRITE_SHORT((short)m_SndRoomtype); // sequence number
+		MESSAGE_END();
 	}
 
 	// Send the current bhopcap state.

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -115,9 +115,10 @@ public:
 	int					m_afButtonPressed;
 	int					m_afButtonReleased;
 
-	edict_t			   *m_pentSndLast;			// last sound entity to modify player room type
-	float				m_flSndRoomtype;		// last roomtype set by sound entity
+	edict_t				*m_pentSndLast;			// last sound entity to modify player room type
+	int					m_SndRoomtype;		// last roomtype set by sound entity
 	float				m_flSndRange;			// dist from player to sound entity
+	int					m_ClientSndRoomtype;
 
 	float				m_flFallVelocity;
 

--- a/dlls/sound.cpp
+++ b/dlls/sound.cpp
@@ -814,7 +814,7 @@ public:
 	static TYPEDESCRIPTION m_SaveData[];
 
 	float m_flRadius;
-	float m_flRoomtype;
+	int m_Roomtype;
 };
 
 LINK_ENTITY_TO_CLASS( env_sound, CEnvSound )
@@ -822,7 +822,7 @@ LINK_ENTITY_TO_CLASS( env_sound, CEnvSound )
 TYPEDESCRIPTION	CEnvSound::m_SaveData[] =
 {
 	DEFINE_FIELD( CEnvSound, m_flRadius, FIELD_FLOAT ),
-	DEFINE_FIELD( CEnvSound, m_flRoomtype, FIELD_FLOAT ),
+	DEFINE_FIELD( CEnvSound, m_Roomtype, FIELD_INTEGER ),
 };
 
 IMPLEMENT_SAVERESTORE( CEnvSound, CPointEntity )
@@ -836,7 +836,7 @@ void CEnvSound::KeyValue( KeyValueData *pkvd )
 	}
 	if( FStrEq( pkvd->szKeyName, "roomtype" ) )
 	{
-		m_flRoomtype = atof( pkvd->szValue );
+		m_Roomtype = atoi( pkvd->szValue );
 		pkvd->fHandled = TRUE;
 	}
 }
@@ -902,7 +902,7 @@ void CEnvSound::Think( void )
 	{
 		// this is the entity currently affecting player, check
 		// for validity
-		if( pPlayer->m_flSndRoomtype != 0 && pPlayer->m_flSndRange != 0 )
+		if( pPlayer->m_SndRoomtype != 0 && pPlayer->m_flSndRange != 0 )
 		{
 			// we're looking at a valid sound entity affecting
 			// player, make sure it's still valid, update range
@@ -914,11 +914,11 @@ void CEnvSound::Think( void )
 			else
 			{
 				// current sound entity affecting player is no longer valid,
-				// flag this state by clearing room_type and range.
+				// flag this state by clearing source handle and range.
 				// NOTE: we do not actually change the player's room_type
 				// NOTE: until we have a new valid room_type to change it to.
 				pPlayer->m_flSndRange = 0;
-				pPlayer->m_flSndRoomtype = 0;
+				pPlayer->m_pentSndLast = 0;
 				goto env_sound_Think_slow;
 			}
 		}
@@ -938,18 +938,10 @@ void CEnvSound::Think( void )
 		{
 			// new entity is closer to player, so it wins.
 			pPlayer->m_pentSndLast = ENT( pev );
-			pPlayer->m_flSndRoomtype = m_flRoomtype;
+			pPlayer->m_SndRoomtype = m_Roomtype;
 			pPlayer->m_flSndRange = flRange;
 
-			// send room_type command to player's server.
-			// this should be a rare event - once per change of room_type
-			// only!
-
-			//CLIENT_COMMAND( pentPlayer, "room_type %f", m_flRoomtype );
-
-			MESSAGE_BEGIN( MSG_ONE, SVC_ROOMTYPE, NULL, pentPlayer );		// use the magic #1 for "one client"
-				WRITE_SHORT( (short)m_flRoomtype );					// sequence number
-			MESSAGE_END();
+			// New room type is sent to player in CBasePlayer::UpdateClientData.
 
 			// crank up nextthink rate for new active sound entity
 			// by falling through to think_fast...


### PR DESCRIPTION
Like https://github.com/SamVanheer/halflife-updated/commit/bc3add9715046f12ace03602cd09c83b5fd78717 but didn't replicate the reset on level transition. Not sure if it's needed at all.