### PR TITLE
[opfor] Replicate Otis KeyValue bug from Opposing Force

### DIFF
--- a/dlls/gearbox/otis.cpp
+++ b/dlls/gearbox/otis.cpp
@@ -392,7 +392,7 @@ void COtis::KeyValue(KeyValueData *pkvd)
 		pkvd->fHandled = TRUE;
 	}
 	else
-		CBarney::KeyValue(pkvd);
+		CBaseMonster::KeyValue(pkvd);
 }
 
 


### PR DESCRIPTION
`Soldier's Tale` mod has Otis with `Suspicious` parameter set to 1. This does not do anything in Opposing Force due to the bug. But if Otis takes this parameter into account, it will attack the player. So we must replicate the bug.