### PR TITLE
server: func_tank: prevent domain error on barrel adjust

### DIFF
--- a/dlls/func_tank.cpp
+++ b/dlls/func_tank.cpp
@@ -626,12 +626,14 @@ void CFuncTank::AdjustAnglesForBarrel( Vector &angles, float distance )
 		if( m_barrelPos.y )
 		{
 			r2 = m_barrelPos.y * m_barrelPos.y;
-			angles.y += ( 180.0f / M_PI_F ) * atan2( m_barrelPos.y, sqrt( d2 - r2 ) );
+			if( d2 > r2 )
+				angles.y += ( 180.0f / M_PI_F ) * atan2( m_barrelPos.y, sqrt( d2 - r2 ) );
 		}
 		if( m_barrelPos.z )
 		{
 			r2 = m_barrelPos.z * m_barrelPos.z;
-			angles.x += ( 180.0f / M_PI_F ) * atan2( -m_barrelPos.z, sqrt( d2 - r2 ) );
+			if( d2 > r2 )
+				angles.x += ( 180.0f / M_PI_F ) * atan2( -m_barrelPos.z, sqrt( d2 - r2 ) );
 		}
 	}
 }


### PR DESCRIPTION
When target is too close to the tank origin, `d2 - r2` expression may become negative causing domain error on square root, and poisoning other fields and even other entities with NaN

This can be easily tested by jumping on a tank head on `c2a5b`.

I'm not sure if we should take absolute value or zero in this case.