### PR TITLE
Add a cvar fixing pushable excessive acceleration

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -26,6 +26,7 @@
 #include "func_break.h"
 #include "decals.h"
 #include "explode.h"
+#include "game.h"
 
 extern DLL_GLOBAL Vector	g_vecAttackDir;
 
@@ -925,12 +926,24 @@ void CPushable::Move( CBaseEntity *pOther, int push )
 		return;
 	}
 
-	// g-cont. fix pushable acceleration bug (reverted as it used in mods)
 	if( pOther->IsPlayer() )
 	{
-		// Don't push unless the player is pushing forward and NOT use (pull)
-		if( push && !( pevToucher->button & ( IN_FORWARD | IN_USE ) ) )
-			return;
+		// g-cont. fix pushable acceleration bug (now implemented as cvar)
+		if (pushablemode.value == 1)
+		{
+			// Allow player push when moving right, left and back too
+			if ( push && !(pevToucher->button & (IN_FORWARD|IN_MOVERIGHT|IN_MOVELEFT|IN_BACK)) )
+				return;
+			// Require player walking back when applying '+use' on pushable
+			if ( !push && !(pevToucher->button & (IN_BACK)) )
+				return;
+		}
+		else
+		{
+			// Don't push unless the player is pushing forward and NOT use (pull)
+			if( push && !( pevToucher->button & ( IN_FORWARD | IN_USE ) ) )
+				return;
+		}
 		playerTouch = 1;
 	}
 
@@ -950,6 +963,13 @@ void CPushable::Move( CBaseEntity *pOther, int push )
 	}
 	else 
 		factor = 0.25f;
+
+	// Spirit fix for pushable acceleration
+	if (pushablemode.value == 2)
+	{
+		if (!push)
+			factor *= 0.5f;
+	}
 
 	pev->velocity.x += pevToucher->velocity.x * factor;
 	pev->velocity.y += pevToucher->velocity.y * factor;

--- a/dlls/game.cpp
+++ b/dlls/game.cpp
@@ -38,6 +38,7 @@ cvar_t satchelfix	= { "satchelfix", "0", FCVAR_SERVER };
 cvar_t explosionfix	= { "explosionfix", "0", FCVAR_SERVER };
 cvar_t monsteryawspeedfix	= { "monsteryawspeedfix", "1", FCVAR_SERVER };
 cvar_t corpsephysics = { "corpsephysics", "0", FCVAR_SERVER };
+cvar_t pushablemode = { "pushablemode", "0", FCVAR_SERVER };
 cvar_t forcerespawn	= { "mp_forcerespawn","1", FCVAR_SERVER };
 cvar_t flashlight	= { "mp_flashlight","0", FCVAR_SERVER };
 cvar_t aimcrosshair	= { "mp_autocrosshair","1", FCVAR_SERVER };
@@ -491,6 +492,7 @@ void GameDLLInit( void )
 	CVAR_REGISTER( &explosionfix );
 	CVAR_REGISTER( &monsteryawspeedfix );
 	CVAR_REGISTER( &corpsephysics );
+	CVAR_REGISTER( &pushablemode );
 	CVAR_REGISTER( &forcerespawn );
 	CVAR_REGISTER( &flashlight );
 	CVAR_REGISTER( &aimcrosshair );

--- a/dlls/game.h
+++ b/dlls/game.h
@@ -33,6 +33,7 @@ extern cvar_t satchelfix;
 extern cvar_t explosionfix;
 extern cvar_t monsteryawspeedfix;
 extern cvar_t corpsephysics;
+extern cvar_t pushablemode;
 extern cvar_t forcerespawn;
 extern cvar_t flashlight;
 extern cvar_t aimcrosshair;


### PR DESCRIPTION
Get back g-cont fix for pushable, but put it under the cvar.

Note that it does more than just preventing excessive acceleration when pushing forward and using the pushable at the same time. G-cont's code also allows pushing by moving backwards and to the left or right side.

I also included a Spirit mode for pushable which just decreases the speed when pushable is 'used' by a player. This check should be removed when merging the code into `sohl1.2` branch. Maybe we don't need it in master at all. What do you think?