### PR TITLE
Fix babyvoltigore attack

### DIFF
--- a/dlls/gearbox/voltigore.cpp
+++ b/dlls/gearbox/voltigore.cpp
@@ -1226,6 +1226,8 @@ public:
 	Schedule_t* GetSchedule();
 	Schedule_t* GetScheduleOfType(int Type);
 
+	CBaseEntity *CheckTraceHullAttack( float flDist, int iDamage, int iDmgType );
+
 	virtual int SizeForGrapple() { return GRAPPLE_SMALL; }
 };
 
@@ -1274,7 +1276,7 @@ void CBabyVoltigore::HandleAnimEvent(MonsterEvent_t* pEvent)
 
 	case VOLTIGORE_AE_PUNCH_SINGLE:
 	{
-		CBaseEntity *pHurt = CheckTraceHullAttack(70, gSkillData.babyVoltigoreDmgPunch, DMG_CLUB | DMG_ALWAYSGIB);
+		CBaseEntity *pHurt = CheckTraceHullAttack(64, gSkillData.babyVoltigoreDmgPunch, DMG_CLUB );
 		if (pHurt)
 		{
 			if (FBitSet(pHurt->pev->flags, FL_MONSTER|FL_CLIENT))
@@ -1300,7 +1302,7 @@ void CBabyVoltigore::HandleAnimEvent(MonsterEvent_t* pEvent)
 
 	case VOLTIGORE_AE_PUNCH_BOTH:
 	{
-		CBaseEntity *pHurt = CheckTraceHullAttack(70, gSkillData.babyVoltigoreDmgPunch, DMG_CLUB | DMG_ALWAYSGIB);
+		CBaseEntity *pHurt = CheckTraceHullAttack(64, gSkillData.babyVoltigoreDmgPunch, DMG_CLUB );
 		if (pHurt)
 		{
 			if (FBitSet(pHurt->pev->flags, FL_MONSTER|FL_CLIENT))
@@ -1404,6 +1406,8 @@ Schedule_t *CBabyVoltigore::GetSchedule(void)
 
 		break;
 	}
+	default:
+		break;
 	}
 
 	return CBaseMonster::GetSchedule();
@@ -1421,4 +1425,31 @@ Schedule_t *CBabyVoltigore::GetScheduleOfType(int Type)
 		return CVoltigore::GetScheduleOfType(Type);
 		break;
 	}
+}
+
+CBaseEntity *CBabyVoltigore::CheckTraceHullAttack( float flDist, int iDamage, int iDmgType )
+{
+	TraceResult tr;
+
+	UTIL_MakeAimVectors( pev->angles );
+
+	Vector vecStart = pev->origin;
+	vecStart.z += pev->size.z;
+	Vector vecEnd = vecStart + ( gpGlobals->v_forward * flDist );
+
+	UTIL_TraceHull( vecStart, vecEnd, dont_ignore_monsters, head_hull, ENT( pev ), &tr );
+
+	if( tr.pHit )
+	{
+		CBaseEntity *pEntity = CBaseEntity::Instance( tr.pHit );
+
+		if( iDamage > 0 )
+		{
+			pEntity->TakeDamage( pev, pev, iDamage, iDmgType );
+		}
+
+		return pEntity;
+	}
+
+	return NULL;
 }


### PR DESCRIPTION
Baby voltigores are small and need their `CheckTraceHullAttack`, otherwise they hit the world. Also removed redundant `DMG_ALWAYSGIB` flag for damage type.