### PR TITLE
Fixes for M249

### DIFF
--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -1984,7 +1984,8 @@ void EV_FireM249( event_args_t *args )
 
 	AngleVectors( angles, forward, right, up );
 
-	shell = gEngfuncs.pEventAPI->EV_FindModelIndex( "models/saw_shell.mdl" );// brass shell
+	const bool bAlternatingEject = args->bparam1 != 0;
+	shell = bAlternatingEject ? gEngfuncs.pEventAPI->EV_FindModelIndex("models/saw_link.mdl") : gEngfuncs.pEventAPI->EV_FindModelIndex( "models/saw_shell.mdl" );// brass shell
 
 	if( EV_IsLocal( idx ) )
 	{

--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -2000,18 +2000,7 @@ void EV_FireM249( event_args_t *args )
 
 	EV_EjectBrass( ShellOrigin, ShellVelocity, angles[YAW], shell, TE_BOUNCE_SHELL );
 
-	switch( gEngfuncs.pfnRandomLong( 0, 2 ) )
-	{
-	case 0:
-		gEngfuncs.pEventAPI->EV_PlaySound( idx, origin, CHAN_WEAPON, "weapons/saw_fire1.wav", 1, ATTN_NORM, 0, PITCH_NORM);
-		break;
-	case 1:
-		gEngfuncs.pEventAPI->EV_PlaySound( idx, origin, CHAN_WEAPON, "weapons/saw_fire2.wav", 1, ATTN_NORM, 0, PITCH_NORM);
-		break;
-	case 2:
-		gEngfuncs.pEventAPI->EV_PlaySound( idx, origin, CHAN_WEAPON, "weapons/saw_fire3.wav", 1, ATTN_NORM, 0, PITCH_NORM);
-		break;
-	}
+	gEngfuncs.pEventAPI->EV_PlaySound( idx, origin, CHAN_WEAPON, "weapons/saw_fire1.wav", 1, ATTN_NORM, 0, PITCH_NORM);
 
 	EV_GetGunPosition( args, vecSrc, origin );
 	VectorCopy( forward, vecAiming );

--- a/dlls/gearbox/m249.cpp
+++ b/dlls/gearbox/m249.cpp
@@ -295,7 +295,7 @@ int CM249::BodyFromClip(int clip)
 {
 	if (clip == 0) {
 		return 8;
-	} else if (clip > 0 && clip < 8) {
+	} else if (clip > 0 && clip <= 8) {
 		return 9 - clip;
 	} else {
 		return 0;

--- a/dlls/gearbox/m249.cpp
+++ b/dlls/gearbox/m249.cpp
@@ -70,8 +70,6 @@ void CM249::Precache(void)
 	PRECACHE_SOUND("items/9mmclip1.wav");
 
 	PRECACHE_SOUND("weapons/saw_fire1.wav");
-	PRECACHE_SOUND("weapons/saw_fire2.wav");
-	PRECACHE_SOUND("weapons/saw_fire3.wav");
 
 	PRECACHE_SOUND("weapons/saw_reload.wav");
 	PRECACHE_SOUND("weapons/saw_reload2.wav");

--- a/dlls/gearbox/m249.cpp
+++ b/dlls/gearbox/m249.cpp
@@ -51,6 +51,7 @@ void CM249::Spawn()
 	m_iDefaultAmmo = M249_DEFAULT_GIVE;
 
 	m_fInSpecialReload = 0;
+	m_bAlternatingEject = false;
 
 	FallInit();// get ready to fall down.
 }
@@ -63,6 +64,7 @@ void CM249::Precache(void)
 	PRECACHE_MODEL("models/p_saw.mdl");
 
 	m_iShell = PRECACHE_MODEL("models/saw_shell.mdl");// brass shellTE_MODEL
+	m_iLink = PRECACHE_MODEL("models/saw_link.mdl");
 
 	PRECACHE_MODEL("models/w_saw_clip.mdl");
 	PRECACHE_SOUND("items/9mmclip1.wav");
@@ -146,6 +148,7 @@ void CM249::PrimaryAttack()
 
 	m_iClip--;
 	UpdateTape();
+	m_bAlternatingEject = !m_bAlternatingEject;
 	m_pPlayer->pev->effects = (int)(m_pPlayer->pev->effects) | EF_MUZZLEFLASH;
 
 	// player "shoot" animation
@@ -177,7 +180,7 @@ void CM249::PrimaryAttack()
 	flags = 0;
 #endif
 
-	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usM249, 0.0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y, 0, pev->body, 0, 0);
+	PLAYBACK_EVENT_FULL(flags, m_pPlayer->edict(), m_usM249, 0.0, (float *)&g_vecZero, (float *)&g_vecZero, vecDir.x, vecDir.y, 0, pev->body, m_bAlternatingEject ? 1 : 0, 0);
 
 
 #if !CLIENT_DLL

--- a/dlls/weapons.h
+++ b/dlls/weapons.h
@@ -1252,6 +1252,8 @@ public:
 	virtual BOOL ShouldWeaponIdle(void) { return TRUE; }
 	float m_flNextAnimTime;
 	int m_iShell;
+	int m_iLink;
+	bool m_bAlternatingEject;
 
 	virtual BOOL UseDecrement(void)
 	{


### PR DESCRIPTION
* Fix skipping the m249 submodel 1 when updating the cartridge belt. The bug is presented in the original Opposing Force.
* Alternate between shell and link ejection in M249 (was a missing feature).
* Remove usage of redundant m249 fire sounds. `saw_fire2.wav` and `saw_fire3.wav` are exactly the same as `saw_fire1.wav`. Also opfor code uses only `saw_fire1.wav` anyway.