### PR TITLE
[SoHL] Fix talkmonster save-restore: add Decline sentence and Speak As

### DIFF
--- a/dlls/talkmonster.cpp
+++ b/dlls/talkmonster.cpp
@@ -43,6 +43,8 @@ TYPEDESCRIPTION	CTalkMonster::m_SaveData[] =
 	DEFINE_FIELD( CTalkMonster, m_useTime, FIELD_TIME ),
 	DEFINE_FIELD( CTalkMonster, m_iszUse, FIELD_STRING ),
 	DEFINE_FIELD( CTalkMonster, m_iszUnUse, FIELD_STRING ),
+	DEFINE_FIELD( CTalkMonster, m_iszDecline, FIELD_STRING ), //LRC
+	DEFINE_FIELD( CTalkMonster, m_iszSpeakAs, FIELD_STRING ), //LRC
 	DEFINE_FIELD( CTalkMonster, m_flLastSaidSmelled, FIELD_TIME ),
 	DEFINE_FIELD( CTalkMonster, m_flStopTalkTime, FIELD_TIME ),
 	DEFINE_FIELD( CTalkMonster, m_hTalkTarget, FIELD_EHANDLE ),

--- a/dlls/talkmonster.h
+++ b/dlls/talkmonster.h
@@ -166,8 +166,8 @@ public:
 	float		m_useTime;						// Don't allow +USE until this time
 	string_t		m_iszUse;						// Custom +USE sentence group (follow)
 	string_t		m_iszUnUse;						// Custom +USE sentence group (stop following)
-	int			m_iszDecline;					// Custom +USE sentence group (refuse to follow) LRC
-	int			m_iszSpeakAs;					// Change the prefix for all this monster's speeches LRC
+	string_t		m_iszDecline;					// Custom +USE sentence group (refuse to follow) LRC
+	string_t		m_iszSpeakAs;					// Change the prefix for all this monster's speeches LRC
 
 	float		m_flLastSaidSmelled;// last time we talked about something that stinks
 	float		m_flStopTalkTime;// when in the future that I'll be done saying this sentence.


### PR DESCRIPTION
Also changed `m_iszDecline` and `m_iszSpeakAs` declarations to `string_t`