### PR TITLE
WIP: Add mod option for legacy mods that had _i386 postfix on Linux builds

### DIFF
--- a/cmake/LibraryNaming.cmake
+++ b/cmake/LibraryNaming.cmake
@@ -115,6 +115,12 @@ endif()
 if(XASH_AMD64)
 	set(BUILDARCH "amd64")
 elseif(XASH_X86)
+	if(SERVER_USES_OLD_I386_POSTFIX AND XASH_LINUX)
+		set(APPEND_I386 YES)
+	else
+		set(APPEND_I386 NO)
+	endif()
+
 	if(XASH_WIN32 OR XASH_LINUX OR XASH_APPLE)
 		set(BUILDARCH "") # no prefix for default OS
 	else()
@@ -190,6 +196,12 @@ elseif(BUILDARCH)
 	set(POSTFIX "_${BUILDARCH}")
 else()
 	set(POSTFIX "")
+endif()
+
+if(APPEND_I386)
+	set(SERVER_POSTFIX "_i386")
+else()
+	set(SERVER_POSTFIX "${POSTFIX}")
 endif()
 
 message(STATUS "Library postfix: " ${POSTFIX})

--- a/mod_options.txt
+++ b/mod_options.txt
@@ -9,6 +9,7 @@ HANDGRENADE_DEPLOY_FIX=OFF # Handgrenade deploy animation fix after finishing a 
 WEAPONS_ANIMATION_TIMES_FIX=OFF # Animation times fix for some weapons
 OEM_BUILD=OFF # OEM Build
 HLDEMO_BUILD=OFF # Demo Build
+SERVER_USES_OLD_I386_POSTFIX=OFF # Add _i386 on linux-i386 builds
 
 GAMEDIR=valve # Gamedir path
 SERVER_INSTALL_DIR=dlls # Where put server dll

--- a/scripts/waifulib/library_naming.py
+++ b/scripts/waifulib/library_naming.py
@@ -73,6 +73,8 @@ def configure(conf):
 
 	conf.multicheck(*tests, msg = '', mandatory = False, quiet = True)
 
+	append_i386 = False
+
 	# engine/common/build.c
 	if conf.env.XASH_ANDROID:
 		buildos = "android"
@@ -107,6 +109,9 @@ def configure(conf):
 	if conf.env.XASH_AMD64:
 		buildarch = "amd64"
 	elif conf.env.XASH_X86:
+		if conf.env.SERVER_USES_OLD_I386_POSTFIX and conf.env.XASH_LINUX:
+			append_i386 = True
+
 		if conf.env.XASH_WIN32 or conf.env.XASH_LINUX or conf.env.XASH_APPLE:
 			buildarch = ""
 		else:
@@ -174,5 +179,10 @@ def configure(conf):
 		conf.env.POSTFIX = '_%s' % buildarch
 	else:
 		conf.env.POSTFIX = ''
+
+	if append_i386:
+		conf.env.SERVER_POSTFIX = '_i386'
+	else:
+		conf.env.SERVER_POSTFIX = conf.env.POSTFIX
 
 	conf.end_msg(conf.env.POSTFIX)


### PR DESCRIPTION
On 32-bit x86 Linux turns server library to be `hl_i386.so` instead of `hl.so`.

Probably incompatible with old WON HLDS builds, but the purpose is to be compatible with legacy naming in `liblist.gam`.