### PR TITLE
Reset fov on crossbow holster

### DIFF
--- a/dlls/crossbow.cpp
+++ b/dlls/crossbow.cpp
@@ -324,7 +324,7 @@ void CCrossbow::Holster( int skiplocal /* = 0 */ )
 {
 	m_fInReload = FALSE;// cancel any reload in progress.
 
-	if( m_fInZoom )
+	if( m_pPlayer->pev->fov != 0 )
 	{
 		SecondaryAttack();
 	}


### PR DESCRIPTION
In this sdk we restore player's fov after the save-restore
https://github.com/FWGS/hlsdk-portable/blob/04e56448f25a5061f16c063f462d6cc61da1538e/dlls/player.cpp#L2927
This leads to another bug when switching to weapon after save-restore doesn't reset zoom effect.
To reproduce:
1. Zoom in crossbow
2. Save
3. Load
4. Switch to other weapon

To fix this I use the same condition in `Holster` as the one that is already used in `Reload`, i.e. checking the fov instead of `m_fInZoom` (which is not get saved).

However, I can imagine other situations when fov doesn't reset. E.g. if player was stripped of weapons while in zoom. These need to be tested.