### PR TITLE
When finding nearest friend, skip the dying ones as well

### DIFF
--- a/dlls/talkmonster.cpp
+++ b/dlls/talkmonster.cpp
@@ -791,7 +791,7 @@ CBaseEntity *CTalkMonster::FindNearestFriend( BOOL fPlayer )
 		// for each friend in this bsp...
 		while( ( pFriend = UTIL_FindEntityByClassname( pFriend, pszFriend ) ) )
 		{
-			if( pFriend == this || !pFriend->IsAlive() )
+			if( pFriend == this || !pFriend->IsAlive() || pFriend->pev->deadflag != DEAD_NO )
 				// don't talk to self or dead people
 				continue;
 


### PR DESCRIPTION
Some talkmonster code leads to the monster changing their schedule.

https://github.com/FWGS/hlsdk-portable/blob/17b34aa42b2060706deb20aa82df0ea2766e1b18/dlls/talkmonster.cpp#L1154-L1161

https://github.com/FWGS/hlsdk-portable/blob/17b34aa42b2060706deb20aa82df0ea2766e1b18/dlls/talkmonster.cpp#L1140-L1145

The `FindNearestFriend` (used in both cases) can return a dying (but not dead yet) monster because `IsAlive` is implemented differently for monsters (it returns true if monster is in dying animation).

To reproduce the bug:
1. Have two monster_barneys nearby
2. Kill one of them.
3. Kill the second one while the first one is still in dying animation.

The first barney will play a death sound two times because at the time when the second barney takes damage, it makes the first barney change his schedule to `slIdleStopShooting`, and then he gets back to the dying schedule since he's in the dead state, playing the death sound again via `TASK_SOUND_DIE`.
Same thing potentially can happen if the monster that is chosen to answer the question is dying at the moment of question being asked, but it's harder to reproduce.