### PR TITLE
Fix rapid swing bug for poolstick

### DIFF
--- a/dlls/asheep/poolstick.cpp
+++ b/dlls/asheep/poolstick.cpp
@@ -286,7 +286,12 @@ int CPoolstick::Swing( int fFirst )
 				}
 				m_pPlayer->m_iWeaponVolume = POOLSTICK_BODYHIT_VOLUME;
 				if ( !pEntity->IsAlive() )
+				{
+#if CROWBAR_FIX_RAPID_CROWBAR
+					  m_flNextPrimaryAttack = GetNextAttackDelay(0.25);
+#endif
 					  return TRUE;
+				}
 				else
 					  flVol = 0.1;
 


### PR DESCRIPTION
A simple patch that prevents the poolstick from being swung too rapidly. Uses the same delay code from the crowbar.