### PR TITLE
Fix osprey save-restore. Fix #407

### DIFF
--- a/dlls/osprey.h
+++ b/dlls/osprey.h
@@ -38,7 +38,7 @@ public:
 	void EXPORT DeployThink(void);
 	void Flight(void);
 	void EXPORT HitTouch(CBaseEntity *pOther);
-	virtual void EXPORT FindAllThink(void);
+	void EXPORT FindAllThink(void);
 	void EXPORT HoverThink(void);
 	virtual CBaseMonster *MakeGrunt(Vector vecSrc);
 	void EXPORT CrashTouch(CBaseEntity *pOther);


### PR DESCRIPTION
The Think function shouldn't and doesn't need to be virtual.