### PR TITLE
Add mention of Windows SDK in build Prerequisites [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git clone --recursive https://github.com/FWGS/hlsdk-portable
 
 ### Prerequisites
 
-Install and run [Visual Studio Installer](https://visualstudio.microsoft.com/downloads/). The installer allows you to choose specific components. Select `Desktop development with C++`. You can untick everything you don't need in Installation details, but you must keep `MSVC` ticked. You may also keep `C++ CMake tools for Windows` ticked as you'll need **cmake**. Alternatively you can install **cmake** from the [cmake.org](https://cmake.org/download/) and during installation tick *Add to the PATH...*.
+Install and run [Visual Studio Installer](https://visualstudio.microsoft.com/downloads/). The installer allows you to choose specific components. Select `Desktop development with C++`. You can untick everything you don't need in Installation details, but you must keep `MSVC` and corresponding Windows SDK (e.g. Windows 10 SDK or Windows 11 SDK) ticked. You may also keep `C++ CMake tools for Windows` ticked as you'll need **cmake**. Alternatively you can install **cmake** from the [cmake.org](https://cmake.org/download/) and during installation tick *Add to the PATH...*.
 
 ### Opening command prompt
 


### PR DESCRIPTION
It's been reported that without Windows SDK installed the cmake configure step produces errors like
```
No CMAKE_C_COMPILER could be found.
No CMAKE_CXX_COMPILER could be found
```
I believe it has to do something with checks in cmake when testing if compilers are set up correctly and this check relying on the presence of some tools available only when Windows SDK is installed (e.g. rc.exe).

As an alternative we could look at changing the CMakeListst.txt file so it works without Windows SDK installed but I don't know what changes should be done.