### PR TITLE
HL25 HUD

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -873,6 +873,7 @@ int CHudAmmo::Draw( float flTime )
 
 	// Does this weapon have a clip?
 	y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2;
+	y += gHUD.m_iHudNumbersYOffset; // a1ba: fix HL25 HUD vertical inconsistensy
 
 	// Does weapon have any ammo at all?
 	if( m_pWeapon->iAmmoType > 0 )

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -75,10 +75,7 @@ void WeaponsResource::LoadWeaponSprites( WEAPON *pWeapon )
 {
 	int i, iRes;
 
-	if( ScreenWidth < 640 )
-		iRes = 320;
-	else
-		iRes = 640;
+	iRes = GetSpriteRes( ScreenWidth, ScreenHeight );
 
 	char sz[256];
 

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -325,16 +325,19 @@ int CHudAmmo::VidInit( void )
 	// If we've already loaded weapons, let's get new sprites
 	gWR.LoadAllWeaponSprites();
 
-	if( ScreenWidth >= 640 )
-	{
-		giABWidth = 20;
-		giABHeight = 4;
-	}
+	const int res = GetSpriteRes( ScreenWidth, ScreenHeight );
+	int factor;
+	if( res >= 2560 )
+		factor = 4;
+	else if( res >= 1280 )
+		factor = 3;
+	else if( res >= 640 )
+		factor = 2;
 	else
-	{
-		giABWidth = 10;
-		giABHeight = 2;
-	}
+		factor = 1;
+
+	giABWidth = 10 * factor;
+	giABHeight = 2 * factor;
 
 	return 1;
 }

--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -323,7 +323,7 @@ int CHudAmmo::VidInit( void )
 	giBucketWidth = gHUD.GetSpriteRect( m_HUD_bucket0 ).right - gHUD.GetSpriteRect( m_HUD_bucket0 ).left;
 	giBucketHeight = gHUD.GetSpriteRect( m_HUD_bucket0 ).bottom - gHUD.GetSpriteRect( m_HUD_bucket0 ).top;
 
-	gHR.iHistoryGap = Q_max( gHR.iHistoryGap, gHUD.GetSpriteRect( m_HUD_bucket0 ).bottom - gHUD.GetSpriteRect( m_HUD_bucket0 ).top );
+	gHR.iHistoryGap = gHUD.GetSpriteRect( m_HUD_bucket0 ).bottom - gHUD.GetSpriteRect( m_HUD_bucket0 ).top;
 
 	// If we've already loaded weapons, let's get new sprites
 	gWR.LoadAllWeaponSprites();

--- a/cl_dll/ammohistory.cpp
+++ b/cl_dll/ammohistory.cpp
@@ -142,7 +142,7 @@ int HistoryResource::DrawAmmoHistory( float flTime )
 				// do not draw black console string
 				if( !( ( hud_textmode->value == 2 ) && ( scale < 200 ) ) )
 					// Draw the number
-					gHUD.DrawHudNumberString( xpos - 10, ypos, xpos - 100, rgAmmoHistory[i].iCount, r, g, b );
+					gHUD.DrawHudNumberString( xpos - 14, ypos, xpos - 104, rgAmmoHistory[i].iCount, r, g, b );
 			}
 			else if( rgAmmoHistory[i].type == HISTSLOT_WEAP )
 			{

--- a/cl_dll/ammohistory.cpp
+++ b/cl_dll/ammohistory.cpp
@@ -131,7 +131,7 @@ int HistoryResource::DrawAmmoHistory( float flTime )
 
 				// Draw the pic
 				int ypos = ScreenHeight - (AMMO_PICKUP_PICK_HEIGHT + (AMMO_PICKUP_GAP * i));
-				int xpos = ScreenWidth - 24;
+				int xpos = ScreenWidth - (rcPic.right - rcPic.left);
 				if( spr && *spr )    // weapon isn't loaded yet so just don't draw the pic
 				{
 					// the dll has to make sure it has sent info the weapons you need

--- a/cl_dll/battery.cpp
+++ b/cl_dll/battery.cpp
@@ -109,7 +109,11 @@ int CHudBattery::Draw( float flTime )
 	int iOffset = ( m_prc1->bottom - m_prc1->top ) / 6;
 
 	y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2;
-	x = ScreenWidth / 5;
+
+	if( gHUD.IsHL25( )) // a1ba: HL25 style
+		x = ( m_prc1->right - m_prc1->left ) * 3;
+	else
+		x = ScreenWidth / 5;
 
 	// make sure we have the right sprite handles
 	if( !m_hSprite1 )
@@ -127,7 +131,7 @@ int CHudBattery::Draw( float flTime )
 	}
 
 	x += ( m_prc1->right - m_prc1->left );
-	x = gHUD.DrawHudNumber( x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iBat, r, g, b );
+	x = gHUD.DrawHudNumber( x, y + gHUD.m_iHudNumbersYOffset, DHN_3DIGITS | DHN_DRAWZERO, m_iBat, r, g, b );
 
 	return 1;
 }

--- a/cl_dll/cl_util.h
+++ b/cl_dll/cl_util.h
@@ -153,6 +153,27 @@ inline void PlaySound( int iSound, float vol ) { gEngfuncs.pfnPlaySoundByIndex( 
 #define Q_min(a, b)  (((a) < (b)) ? (a) : (b))
 #define fabs(x)	   ((x) > 0 ? (x) : 0 - (x))
 
+inline int GetSpriteRes( int width, int height )
+{
+	int i;
+
+	if( width < 640 )
+		i = 320;
+	else if( width < 1280 || !gHUD.m_pAllowHD->value )
+		i = 640;
+	else
+	{
+		if( height <= 720 )
+			i = 640;
+		else if( width <= 2560 || height <= 1600 )
+			i = 1280;
+		else
+			i = 2560;
+	}
+
+	return i;
+}
+
 void ScaleColors( int &r, int &g, int &b, int a );
 
 #define DotProduct(x, y) ((x)[0] * (y)[0] + (x)[1] * (y)[1] + (x)[2] * (y)[2])

--- a/cl_dll/cl_util.h
+++ b/cl_dll/cl_util.h
@@ -171,7 +171,7 @@ inline int GetSpriteRes( int width, int height )
 			i = 2560;
 	}
 
-	return i;
+	return Q_min( i, gHUD.m_iMaxRes );
 }
 
 void ScaleColors( int &r, int &g, int &b, int a );

--- a/cl_dll/health.cpp
+++ b/cl_dll/health.cpp
@@ -226,14 +226,14 @@ int CHudHealth::Draw( float flTime )
 
 		x = CrossWidth + HealthWidth / 2;
 
-		x = gHUD.DrawHudNumber( x, y, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b );
+		x = gHUD.DrawHudNumber( x, y + gHUD.m_iHudNumbersYOffset, DHN_3DIGITS | DHN_DRAWZERO, m_iHealth, r, g, b );
 
 		x += HealthWidth / 2;
 
 		int iHeight = gHUD.m_iFontHeight;
 		int iWidth = HealthWidth / 10;
 		UnpackRGB( r, g, b, RGB_YELLOWISH );
-		FillRGBA( x, y, iWidth, iHeight, r, g, b, a );
+		FillRGBA( x, y + gHUD.m_iHudNumbersYOffset, iWidth, iHeight, r, g, b, a );
 	}
 
 	DrawDamage( flTime );

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -482,13 +482,28 @@ void CHud::VidInit( void )
 	m_hsprLogo = 0;	
 	m_hsprCursor = 0;
 
+	// a1ba: don't break the loading order here and
+	// don't cause memory leak but check
+	// maximum HUD sprite resolution we have
+	m_iMaxRes = 640;
+	client_sprite_t *pSpriteList = m_pSpriteList ? m_pSpriteList :
+		SPR_GetList( "sprites/hud.txt", &m_iSpriteCountAllRes );
+	if( pSpriteList )
+	{
+		for( int i = 0; i < m_iSpriteCountAllRes; i++ )
+		{
+			if( m_iMaxRes < pSpriteList[i].iRes )
+				m_iMaxRes = pSpriteList[i].iRes;
+		}
+	}
+
 	m_iRes = GetSpriteRes( ScreenWidth, ScreenHeight );
 
 	// Only load this once
 	if( !m_pSpriteList )
 	{
 		// we need to load the hud.txt, and all sprites within
-		m_pSpriteList = SPR_GetList( "sprites/hud.txt", &m_iSpriteCountAllRes );
+		m_pSpriteList = pSpriteList;
 
 		if( m_pSpriteList )
 		{

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -379,6 +379,7 @@ void CHud::Init( void )
 	default_fov = CVAR_CREATE( "default_fov", "90", FCVAR_ARCHIVE );
 	m_pCvarStealMouse = CVAR_CREATE( "hud_capturemouse", "1", FCVAR_ARCHIVE );
 	m_pCvarDraw = CVAR_CREATE( "hud_draw", "1", FCVAR_ARCHIVE );
+	m_pAllowHD = CVAR_CREATE ( "hud_allow_hd", "1", FCVAR_ARCHIVE );
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 	cl_viewbob = CVAR_CREATE( "cl_viewbob", "0", FCVAR_ARCHIVE );
 
@@ -481,10 +482,7 @@ void CHud::VidInit( void )
 	m_hsprLogo = 0;	
 	m_hsprCursor = 0;
 
-	if( ScreenWidth < 640 )
-		m_iRes = 320;
-	else
-		m_iRes = 640;
+	m_iRes = GetSpriteRes( ScreenWidth, ScreenHeight );
 
 	// Only load this once
 	if( !m_pSpriteList )

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -555,6 +555,7 @@ public:
 	int		m_iFOV;
 	int		m_Teamplay;
 	int		m_iRes;
+	int		m_iMaxRes;
 	cvar_t  *m_pCvarStealMouse;
 	cvar_t	*m_pCvarDraw;
 	cvar_t  *m_pAllowHD;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -557,6 +557,7 @@ public:
 	int		m_iRes;
 	cvar_t  *m_pCvarStealMouse;
 	cvar_t	*m_pCvarDraw;
+	cvar_t  *m_pAllowHD;
 
 	int m_iFontHeight;
 	int DrawHudNumber( int x, int y, int iFlags, int iNumber, int r, int g, int b );

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -29,6 +29,7 @@
 #include "wrect.h"
 #include "cl_dll.h"
 #include "ammo.h"
+#include "cvardef.h"
 
 #define DHN_DRAWZERO 1
 #define DHN_2DIGITS  2
@@ -556,6 +557,7 @@ public:
 	int		m_Teamplay;
 	int		m_iRes;
 	int		m_iMaxRes;
+	int		m_iHudNumbersYOffset;
 	cvar_t  *m_pCvarStealMouse;
 	cvar_t	*m_pCvarDraw;
 	cvar_t  *m_pAllowHD;
@@ -586,6 +588,13 @@ public:
 	wrect_t& GetSpriteRect( int index )
 	{
 		return m_rgrcRects[index];
+	}
+
+	inline bool IsHL25( void )
+	{
+		// a1ba: only HL25 have higher resolution HUD spritesheets
+		// and only accept HUD style changes if user has allowed HD sprites
+		return m_iMaxRes > 640 && m_pAllowHD->value;
 	}
 	
 	int GetSpriteIndex( const char *SpriteName );	// gets a sprite index, for use in the m_rghSprites[] array

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -148,6 +148,8 @@ int CHud::Redraw( float flTime, int intermission )
 	// if no redrawing is necessary
 	// return 0;
 
+	m_iHudNumbersYOffset = IsHL25() ? m_iFontHeight * 0.2 : 0;
+
 	if( m_pCvarDraw->value )
 	{
 		HUDLIST *pList = m_pHudList;

--- a/cl_dll/util.cpp
+++ b/cl_dll/util.cpp
@@ -123,13 +123,8 @@ void VectorMA( const float *veca, float scale, const float *vecb, float *vecc )
 
 HSPRITE LoadSprite( const char *pszName )
 {
-	int i;
+	int i = GetSpriteRes( ScreenWidth, ScreenHeight );
 	char sz[256];
-
-	if( ScreenWidth < 640 )
-		i = 320;
-	else
-		i = 640;
 
 	sprintf( sz, pszName, i );
 


### PR DESCRIPTION
This set of patches adds support for available since HL25 update HD set of sprite sheets.

Because not every player might like the new HUD look, there is a new cvar `hud_allow_hd` that limits the usage of HD sprites and reverts some style changes, like battery HUD being super close to the left and HUD numbers are shifted down a bit to match the icons (additionally, it fixes HUD inconsistency bug caused by this change, see ValveSoftware/halflife#3728).

There is no way to switch between old and new HUD by toggling `hud_allow_hd` cvar without restarting a level, so I wonder if we should use Xash3D's FCVAR_LATCH extended flag to notify the player that the change will be skipped until server restart.