### PR TITLE
[WIP] Warn mod developer about reaching the GoldSrc sentences limits

### DIFF
--- a/dlls/sound.cpp
+++ b/dlls/sound.cpp
@@ -1341,6 +1341,15 @@ void SENTENCEG_Init()
 
 	g_engfuncs.pfnFreeFile( pMemFile );
 
+	if( gcallsentences >= 2048 )
+	{
+		ALERT( at_warning, "NOTE: this mod might not work properly under GoldSource (post-anniversary update) engine: more than 2048 sentences\n" );
+	}
+	else if( gcallsentences >= 1536 )
+	{
+		ALERT( at_warning, "NOTE: this mod might not work properly under GoldSource (pre-anniversary update) engine: more than 1536 sentences\n" );
+	}
+
 	fSentencesInit = TRUE;
 
 	// init lru lists

--- a/dlls/util.h
+++ b/dlls/util.h
@@ -498,7 +498,7 @@ extern DLL_GLOBAL int			g_Language;
 
 // sentence groups
 #define CBSENTENCENAME_MAX 16
-#define CVOXFILESENTENCEMAX		2048		// max number of sentences in game. NOTE: this must match
+#define CVOXFILESENTENCEMAX		4096		// max number of sentences in game. NOTE: this must match
 							// CVOXFILESENTENCEMAX in engine\sound.h!!!
 
 extern char gszallsentencenames[CVOXFILESENTENCEMAX][CBSENTENCENAME_MAX];


### PR DESCRIPTION
Quick draft for an idea suggested by @FreeSlave 

Should it be more complicated? Should this check be removed without GOLDSOURCE_SUPPORT, which is only for client.dll now?