### PR TITLE
Finding a reason of server crash on the online change

### DIFF
--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -1194,7 +1194,7 @@ void StartFrame( void )
 
 				// have to delay here or engine gives "Tried to write to
 				// uninitialized sizebuf_t" error and crashes...
-				pause_time = gpGlobals->time + 1.0;
+				pause_time = gpGlobals->time + 1;
 				break;
 			}
 			else if( strcmp( cmd, "botskill" ) == 0 )


### PR DESCRIPTION
After enabling dynamical add/remove bots on online change (by min/max settings), found an issue - server crashes sometimes. It mostly happened when more than one players online

With permanent quantity of bots is no problems

As commented in code, there is could be timeout reason.

Please do not merge this PR until testing on YGGverse server will be completed.
But this one commit would be included here.