### PR TITLE
Replace sentences magic numbers with symbolic constants

### DIFF
--- a/dlls/sound.cpp
+++ b/dlls/sound.cpp
@@ -1341,13 +1341,13 @@ void SENTENCEG_Init()
 
 	g_engfuncs.pfnFreeFile( pMemFile );
 
-	if( gcallsentences >= 2048 )
+	if( gcallsentences > CVOXFILESENTENCEMAX_GOLDSOURCE_ANNIVERSARY_25 )
 	{
-		ALERT( at_warning, "NOTE: this mod might not work properly under GoldSource (post-anniversary update) engine: more than 2048 sentences\n" );
+		ALERT( at_warning, "NOTE: this mod might not work properly under GoldSource (post-anniversary update) engine: more than %d sentences\n", CVOXFILESENTENCEMAX_GOLDSOURCE_ANNIVERSARY_25 );
 	}
-	else if( gcallsentences >= 1536 )
+	else if( gcallsentences > CVOXFILESENTENCEMAX_GOLDSOURCE_LEGACY )
 	{
-		ALERT( at_warning, "NOTE: this mod might not work properly under GoldSource (pre-anniversary update) engine: more than 1536 sentences\n" );
+		ALERT( at_warning, "NOTE: this mod might not work properly under GoldSource (pre-anniversary update) engine: more than %d sentences\n", CVOXFILESENTENCEMAX_GOLDSOURCE_LEGACY );
 	}
 
 	fSentencesInit = TRUE;

--- a/dlls/util.h
+++ b/dlls/util.h
@@ -498,7 +498,11 @@ extern DLL_GLOBAL int			g_Language;
 
 // sentence groups
 #define CBSENTENCENAME_MAX 16
-#define CVOXFILESENTENCEMAX		4096		// max number of sentences in game. NOTE: this must match
+
+#define CVOXFILESENTENCEMAX_GOLDSOURCE_LEGACY 1536
+#define CVOXFILESENTENCEMAX_GOLDSOURCE_ANNIVERSARY_25 2048
+#define CVOXFILESENTENCEMAX_XASH3D 4096
+#define CVOXFILESENTENCEMAX CVOXFILESENTENCEMAX_XASH3D // max number of sentences in game. NOTE: this must match
 							// CVOXFILESENTENCEMAX in engine\sound.h!!!
 
 extern char gszallsentencenames[CVOXFILESENTENCEMAX][CBSENTENCENAME_MAX];


### PR DESCRIPTION
I checked it on anniversary update. It does support up to 2048 sentences. So I also changed the conditions to greater than instead of greater-or-equal.