### PR TITLE
Rename EFLAG_MONSTER to EFLAG_FLESH_SOUND

### DIFF
--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -112,7 +112,7 @@ float EV_HLDM_PlayTextureSound( int idx, pmtrace_t *ptr, float *vecSrc, float *v
 
 	// Player
 	if( ( entity >= 1 && entity <= gEngfuncs.GetMaxClients() )
-	    || ( ( ent = gEngfuncs.GetEntityByIndex( entity )) && ( ent->curstate.eflags & EFLAG_MONSTER )))
+	    || ( ( ent = gEngfuncs.GetEntityByIndex( entity )) && ( ent->curstate.eflags & EFLAG_FLESH_SOUND )))
 	{
 		// hit body
 		chTextureType = CHAR_TEX_FLESH;

--- a/common/const.h
+++ b/common/const.h
@@ -127,7 +127,7 @@
 
 // entity flags
 #define EFLAG_SLERP			1	// do studio interpolation of this entity
-#define EFLAG_MONSTER			2
+#define EFLAG_FLESH_SOUND		2
 
 //
 // temp entity events

--- a/dlls/client.cpp
+++ b/dlls/client.cpp
@@ -1313,11 +1313,11 @@ int AddToFullPack( struct entity_state_s *state, int e, edict_t *ent, edict_t *h
 	    && Entity->Classify() != CLASS_NONE
 	    && Entity->Classify() != CLASS_MACHINE )
 	{
-		SetBits( state->eflags, EFLAG_MONSTER );
+		SetBits( state->eflags, EFLAG_FLESH_SOUND );
 	}
 	else
 	{
-		ClearBits( state->eflags, EFLAG_SLERP | EFLAG_MONSTER );
+		ClearBits( state->eflags, EFLAG_SLERP | EFLAG_FLESH_SOUND );
 	}
 
 	return 1;


### PR DESCRIPTION
This is mentioned in default delta.lst shipped with HL25:

```
	DEFINE_DELTA( eflags, DT_INTEGER, 2, 1.0 ), // JoshA: Changed to 2 for EFLAG_FLESH_SOUND to fix flesh sounds on entities. If a mod ships updated DLLs and not this file, they just won't have that fix.
```