### PR TITLE
Fix CControllerZapBall save-restore

### DIFF
--- a/dlls/controller.cpp
+++ b/dlls/controller.cpp
@@ -1303,9 +1303,20 @@ class CControllerZapBall : public CBaseMonster
 	void EXPORT ExplodeTouch( CBaseEntity *pOther );
 
 	EHANDLE m_hOwner;
+
+	virtual int Save( CSave &save );
+	virtual int Restore( CRestore &restore );
+	static TYPEDESCRIPTION m_SaveData[];
 };
 
 LINK_ENTITY_TO_CLASS( controller_energy_ball, CControllerZapBall )
+
+TYPEDESCRIPTION	CControllerZapBall::m_SaveData[] =
+{
+	DEFINE_FIELD( CControllerZapBall, m_hOwner, FIELD_EHANDLE ),
+};
+
+IMPLEMENT_SAVERESTORE( CControllerZapBall, CBaseMonster )
 
 void CControllerZapBall::Spawn( void )
 {


### PR DESCRIPTION
`m_hOwner` doesn't get saved. It makes the energy ball lose its owner on save-restore, which in turns means that the alien controller won't be passed as an attacker.
Not sure if it affects anything in vanilla Half-Life, but it could matter in mods.

You might not merge it but leave it just as a reminder of the bug.