### PR TITLE
Fix func_door_rotating with 'Starts Open' spawnflag

### DIFF
--- a/dlls/doors.cpp
+++ b/dlls/doors.cpp
@@ -892,7 +892,7 @@ void CRotDoor::Spawn( void )
 	{	
 		// swap pos1 and pos2, put door at pos2, invert movement direction
 		pev->angles = m_vecAngle2;
-		Vector vecSav = m_vecAngle1;
+		Vector vecSav = m_vecAngle2;
 		m_vecAngle2 = m_vecAngle1;
 		m_vecAngle1 = vecSav;
 		pev->movedir = pev->movedir * -1.0f;


### PR DESCRIPTION
There's an error in the door angles swap which leads to the rotating door with `Starts open` spawnflag not moving after it was "closed". The Toggle door won't respond to the trigger and non-Toggle door won't return to the position.

This is probably dangerous to merge as some existing maps may rely on this behavior.
I leave this PR just to document the bug.