### PR TITLE
Fix instant camera movement after closing the VGUI menu

### DIFF
--- a/cl_dll/input_goldsource.cpp
+++ b/cl_dll/input_goldsource.cpp
@@ -811,6 +811,11 @@ void GoldSourceInput::IN_GetMouseDelta( int *pOutX, int *pOutY)
 		mx = my = 0;
 	}
 
+	if (ignoreNextDelta)
+	{
+		ignoreNextDelta = false;
+		mx = my = 0;
+	}
 	if(pOutX) *pOutX = mx;
 	if(pOutY) *pOutY = my;
 }
@@ -1580,6 +1585,7 @@ IN_Init
 */
 void GoldSourceInput::IN_Init (void)
 {
+	ignoreNextDelta = false;
 	m_filter				= gEngfuncs.pfnRegisterVariable ( "m_filter","0", FCVAR_ARCHIVE );
 	sensitivity			 = gEngfuncs.pfnRegisterVariable ( "sensitivity","3", FCVAR_ARCHIVE ); // user mouse sensitivity setting.
 
@@ -1678,6 +1684,11 @@ void GoldSourceInput::IN_Init (void)
 
 	IN_StartupMouse ();
 	IN_StartupJoystick ();
+}
+
+void GoldSourceInput::IgnoreNextMouseDelta()
+{
+	ignoreNextDelta = true;
 }
 
 #endif

--- a/cl_dll/input_mouse.cpp
+++ b/cl_dll/input_mouse.cpp
@@ -87,7 +87,12 @@ void IN_ResetMouse()
 	currentInput->IN_ResetMouse();
 }
 
+void IgnoreNextMouseDelta()
+{
+	currentInput->IgnoreNextMouseDelta();
+}
+
 AbstractInput* CurrentMouseInput()
 {
-    return currentInput;
+	return currentInput;
 }

--- a/cl_dll/input_mouse.h
+++ b/cl_dll/input_mouse.h
@@ -21,6 +21,7 @@ public:
 	virtual void IN_Init( void ) = 0;
 	virtual void IN_ResetMouse( void ) = 0;
 	virtual void Joy_AdvancedUpdate( void ) = 0;
+	virtual void IgnoreNextMouseDelta() = 0;
 };
 
 class FWGSInput : public AbstractInput
@@ -39,6 +40,7 @@ public:
 	virtual void IN_Init( void );
 	virtual void IN_ResetMouse( void ) {}
 	virtual void Joy_AdvancedUpdate( void ) {}
+	virtual void IgnoreNextMouseDelta() {}
 
 protected:
 	float ac_forwardmove;
@@ -82,6 +84,7 @@ public:
 	virtual void IN_Init( void );
 	virtual void IN_ResetMouse( void );
 	virtual void Joy_AdvancedUpdate( void );
+	virtual void IgnoreNextMouseDelta();
 
 protected:
 	void IN_GetMouseDelta( int *pOutX, int *pOutY);
@@ -98,6 +101,7 @@ protected:
 	int         old_mouse_x, old_mouse_y, mx_accum, my_accum;
 	int         mouseinitialized;
 	void* sdl2Lib;
+	bool ignoreNextDelta;
 };
 #endif
 

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -58,6 +58,8 @@
 #include "screenfade.h"
 
 void IN_SetVisibleMouse(bool visible);
+void IgnoreNextMouseDelta();
+
 class CCommandMenu;
 
 // Scoreboard positions
@@ -1672,6 +1674,7 @@ void TeamFortressViewport::UpdateCursorState()
 	if( m_pSpectatorPanel->m_menuVisible || m_pCurrentMenu || m_pTeamMenu->isVisible() || GetClientVoiceMgr()->IsInSquelchMode() )
 	{
 		IN_SetVisibleMouse(true);
+		IgnoreNextMouseDelta();
 		App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 		return;
 	}
@@ -1681,6 +1684,7 @@ void TeamFortressViewport::UpdateCursorState()
 		if( gHUD.m_pCvarStealMouse->value != 0.0f )
 		{
 			IN_SetVisibleMouse(true);
+			IgnoreNextMouseDelta();
 			App::getInstance()->setCursorOveride( App::getInstance()->getScheme()->getCursor(Scheme::scu_arrow) );
 			return;
 		}


### PR DESCRIPTION
Fix #454 

The bug doesn't appear on Windows with disabled raw input, so we may limit the fix to Linux and Windows with enabled raw input.
Also the function name is questionable. Probably something like `IN_VGUIMenuShown` would be better. What do you think?

I don't know if joystick input has a similar problem and if it needs a fix.