### PR TITLE
Fix #238

### DIFF
--- a/dlls/ggrenade.cpp
+++ b/dlls/ggrenade.cpp
@@ -278,7 +278,10 @@ void CGrenade::BounceTouch( CBaseEntity *pOther )
 	if( pev->framerate > 1.0f )
 		pev->framerate = 1.0f;
 	else if( pev->framerate < 0.5f )
+	{
 		pev->framerate = 0.0f;
+		pev->frame = 0.0f;
+	}
 }
 
 void CGrenade::SlideTouch( CBaseEntity *pOther )


### PR DESCRIPTION
My proposal for fixing the issue [#238](https://github.com/twhl-community/halflife-updated/issues/238)

Forcefully reset the frame to 0 when animation is no longer played to avoid having the situation when the grenade is stuck on the 'flying' frame.

Note: the frame reset is visible of course, but not too noticeable during the game.

Alternatively we can just revert the commit that made grenades animated in the first place.