### PR TITLE
Reset ammo history slot on HUD reset

### DIFF
--- a/cl_dll/ammohistory.h
+++ b/cl_dll/ammohistory.h
@@ -127,6 +127,7 @@ public:
 	void Reset( void )
 	{
 		memset( rgAmmoHistory, 0, sizeof rgAmmoHistory );
+		iCurrentHistorySlot = 0;
 	}
 
 	int iHistoryGap;


### PR DESCRIPTION
If you get weapons/ammo, restart the game and get weapons/ammo again, the icons will appear higher on the screen even though there's enough space for them to appear at the bottom.

It's because the history slot index is not getting reset.