### PR TITLE
func_breakable shouldn't take damage when it's set to Trigger Only

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -556,7 +556,8 @@ int CBreakable::TakeDamage( entvars_t *pevInflictor, entvars_t *pevAttacker, flo
 	g_vecAttackDir = vecTemp.Normalize();
 
 	// do the damage
-	pev->health -= flDamage;
+	if( pev->takedamage )
+		pev->health -= flDamage;
 	if( pev->health <= 0 )
 	{
 		Killed( pevAttacker, GIB_NORMAL );


### PR DESCRIPTION
When func_breakable is set to Trigger Only, it sets the `pev->takedamage` to `DAMAGE_NO`, but since there's no check for it in `TakeDamage` it still can take damage because some attacks don't check for `pev->takedamage` from outside (e.g. `CheckTraceHullAttack`).

I'm not sure if this fix should be merged as there could be some maps that rely on such behavior.