### PR TITLE
Prevent game_zone_player from transitioning across levels 

### DIFF
--- a/dlls/maprules.cpp
+++ b/dlls/maprules.cpp
@@ -110,6 +110,7 @@ class CRuleBrushEntity : public CRuleEntity
 {
 public:
 	void		Spawn( void );
+	int ObjectCaps() { return CRuleEntity::ObjectCaps() & ~FCAP_ACROSS_TRANSITION; }
 
 private:
 };


### PR DESCRIPTION
`game_zone_player` being a brush entity causes a problem on level transition in singleplayer.

```
Mod_NumForName: *brush-entity-model-number not found
```
