### PR TITLE
Fix null dereference in game_score

### DIFF
--- a/dlls/maprules.cpp
+++ b/dlls/maprules.cpp
@@ -168,7 +168,7 @@ void CGameScore::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE us
 		return;
 
 	// Only players can use this
-	if( pActivator->IsPlayer() )
+	if( pActivator && pActivator->IsPlayer() )
 	{
 		if( AwardToTeam() )
 		{


### PR DESCRIPTION
Sometimes activator is null (e.g. the func_breakable sends null as activator)