### PR TITLE
Fix unreferenced variable.

### DIFF
--- a/dlls/scripted.cpp
+++ b/dlls/scripted.cpp
@@ -1073,7 +1073,7 @@ BOOL CScriptedSentence::AcceptableSpeaker( CBaseToggle *pTarget )
 
 		if( hTarget != 0 )
 		{
-			CBaseMonster *pMonster = (CBaseMonster*)( (CBaseEntity*)hTarget );
+			pMonster = (CBaseMonster*)( (CBaseEntity*)hTarget );
 			if( pev->spawnflags & SF_SENTENCE_FOLLOWERS )
 			{
 				if( pMonster->m_hTargetEnt == 0 || !pMonster->m_hTargetEnt->IsPlayer() )

--- a/dlls/scripted.cpp
+++ b/dlls/scripted.cpp
@@ -1064,7 +1064,6 @@ void CScriptedSentence::DelayThink( void )
 
 BOOL CScriptedSentence::AcceptableSpeaker( CBaseToggle *pTarget )
 {
-	CBaseMonster *pMonster;
 	EHANDLE hTarget;
 
 	if( pTarget )
@@ -1073,7 +1072,7 @@ BOOL CScriptedSentence::AcceptableSpeaker( CBaseToggle *pTarget )
 
 		if( hTarget != 0 )
 		{
-			pMonster = (CBaseMonster*)( (CBaseEntity*)hTarget );
+			CBaseMonster* pMonster = (CBaseMonster*)( (CBaseEntity*)hTarget );
 			if( pev->spawnflags & SF_SENTENCE_FOLLOWERS )
 			{
 				if( pMonster->m_hTargetEnt == 0 || !pMonster->m_hTargetEnt->IsPlayer() )


### PR DESCRIPTION
`pMonster` on line 1067 was unreferenced.

The code has been changed to keep the first declaration so that it follows the same convention as in the other functions (variables declared at the top).