### PR TITLE
Fix nodes and links bounds check.

### DIFF
--- a/dlls/nodes.h
+++ b/dlls/nodes.h
@@ -216,7 +216,7 @@ public:
 	inline	CNode &Node( int i )
 	{
 #if _DEBUG
-		if ( !m_pNodes || i < 0 || i > m_cNodes )
+		if ( !m_pNodes || i < 0 || i >= m_cNodes )
 			ALERT( at_error, "Bad Node!\n" );
 #endif
 		return m_pNodes[i];
@@ -225,7 +225,7 @@ public:
 	inline	CLink &Link( int i )
 	{
 #if _DEBUG
-		if ( !m_pLinkPool || i < 0 || i > m_cLinks )
+		if ( !m_pLinkPool || i < 0 || i >= m_cLinks )
 			ALERT( at_error, "Bad link!\n" );
 #endif
 		return m_pLinkPool[i];


### PR DESCRIPTION
For example, consider the following in nodes.cpp:

https://github.com/FWGS/hlsdk-portable/blob/13086d3b5d7ab24b246160237ebc03bcc3ad0669/dlls/nodes.cpp#L1413-L1416

https://github.com/FWGS/hlsdk-portable/blob/13086d3b5d7ab24b246160237ebc03bcc3ad0669/dlls/nodes.cpp#L2651-L2655

For nodes, `i` should always be less than `m_cNodes` and less than `m_cLinks` for links. Assuming it's the case, if `m_cNodes = 11` then `m_pNodes[11]` should be invalid. If `m_cLinks = 18` then `m_pLinkPool[18]` should also be invalid.

Methods `Node(int i)` and `Link(int i)` check whether `i` is a valid index.

https://github.com/FWGS/hlsdk-portable/blob/13086d3b5d7ab24b246160237ebc03bcc3ad0669/dlls/nodes.h#L219-L220

https://github.com/FWGS/hlsdk-portable/blob/13086d3b5d7ab24b246160237ebc03bcc3ad0669/dlls/nodes.h#L228-L229


In the case of `Node(int i)`, the last out of bound check is `i > m_cNodes`. If `m_cNodes = 11` and `i = 11`, it shouldn't be valid but still passes. The same applies to `Link(int i)`.

### Quick test

1. Build the latest version
2. Open a map (e.g. c2a5a, used in the test)
3. Put a breakpoint on both lines
4. Upon hitting the breakpoint, change `i` to each of the following values and assert:

**Note:** `m_cNodes = 11` and `m_cLinks = 18` in c2a5a.

**Node(int i)**

```text
i = -1, invalid index (OK) (because of i < 0)
i = 0, valid index (OK)
i = 10, valid index (OK)
i = 11, invalid index (FAIL) (because of i > m_cNodes)
```

**Link(int i)**

```text
i = -1, invalid index (OK) (because of i < 0)
i = 0, valid index (OK)
i = 17, valid index (OK)
i = 18, invalid index (FAIL) (because of i > m_cLinks)
```

Changing to `i >= m_cNodes` and `i >= m_cLinks` makes the check work correctly. However, both methods should return NULL if it's invalid.

### Conclusion

Note that it's just from a first look and a quick test. I don't know if there are cases or reasons that justify `i > m_cNodes` and `i > m_cLinks`. Further tests may or may not be required but I won't have time to make an in depth testing for now ~~, so I'll leave this PR as draft~~ . Feel free to leave open, merge or close.