### PR TITLE
Fix max nodes text.

### DIFF
--- a/dlls/nodes.cpp
+++ b/dlls/nodes.cpp
@@ -1587,7 +1587,7 @@ void CNodeEnt::Spawn( void )
 
 	if( WorldGraph.m_cNodes >= MAX_NODES )
 	{
-		ALERT( at_aiconsole, "cNodes > MAX_NODES\n" );
+		ALERT( at_aiconsole, "cNodes >= MAX_NODES\n" );
 		return;
 	}
 


### PR DESCRIPTION
The code prints the enclosing condition but doesn't use the same domain. It should use `>=` instead of `>`.