### PR TITLE
Fix reading angles for DRC_CMD_CAMERA

### DIFF
--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -727,9 +727,9 @@ void CHudSpectator::DirectorMessage( int iSize, void *pbuf )
 			v1[1] = READ_COORD();
 			v1[2] = READ_COORD();	// vJumpOrigin
 
-			v1[0] = READ_COORD();	// view angle
-			v1[1] = READ_COORD();	// vJumpAngles
-			v1[2] = READ_COORD();
+			v2[0] = READ_COORD();	// view angle
+			v2[1] = READ_COORD();	// vJumpAngles
+			v2[2] = READ_COORD();
 
 			f1    = READ_BYTE();	// fov
 			i1    = READ_WORD();	// target


### PR DESCRIPTION
It was reading angles into v1 (where the origin is already stored).
It's weird. Even the steam legacy branch of the Valve repo didn't have this mistake https://github.com/ValveSoftware/halflife/blob/steam_legacy/cl_dll/hud_spectator.cpp#L736-L738