### PR TITLE
Copy vgui.so to the base build directory in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,7 @@ jobs:
       run: |
         schroot --chroot steamrt_scout_i386 -- cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DPOLLY=ON -B build-vgui -S . -DCMAKE_EXE_LINKER_FLAGS="-Wl,--no-undefined" -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="$PWD/dist-vgui"
         cp vgui_support/vgui-dev/lib/vgui.so build-vgui/cl_dll
+        cp vgui_support/vgui-dev/lib/vgui.so build-vgui
         schroot --chroot steamrt_scout_i386 -- cmake --build build-vgui --target all
         schroot --chroot steamrt_scout_i386 -- cmake --build build-vgui --target install
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -64,6 +64,7 @@ jobs:
       run: |
         mkdir -p build/cl_dll
         cp vgui_support/vgui-dev/lib/vgui.so build/cl_dll
+        cp vgui_support/vgui-dev/lib/vgui.so build
     - name: Build on Linux
       if: startsWith(matrix.os, 'ubuntu')
       run: |


### PR DESCRIPTION
After switching to Ninja the vgui autobuild is broken because ninja uses a different current directory.
I kept copying vgui.so to the cl_dll/ intact just in case someone changes generator back to Makefiles.