### PR TITLE
Use latest scout steam runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       CC: ${{ matrix.cc }}
       CXX: ${{ matrix.cxx }}
+      STEAMRT_SNAPSHOT: latest-steam-client-general-availability
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -38,10 +39,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
-        key: ${{ runner.os }}-steam-runtime
+        key: steam-runtime-${{ env.STEAMRT_SNAPSHOT }}
     - name: Download steam-runtime
       if: startsWith(matrix.os, 'ubuntu') && steps.cache-steam-runtime.outputs.cache-hit != 'true'
-      run: wget --no-verbose https://repo.steampowered.com/steamrt-images-scout/snapshots/0.20210610.0/com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
+      run: wget --no-verbose https://repo.steampowered.com/steamrt-images-scout/snapshots/${{ env.STEAMRT_SNAPSHOT }}/com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
     - name: Install steam runtime
       if: startsWith(matrix.os, 'ubuntu')
       run: |

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -15,6 +15,10 @@ on:
         options:
         - 'OFF'
         - 'ON'
+      steamrt_snapshot:
+        type: string
+        description: SteamRT Snapshot
+        default: 'latest-steam-client-general-availability'
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -48,10 +52,10 @@ jobs:
       uses: actions/cache@v4
       with:
         path: com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
-        key: ${{ runner.os }}-steam-runtime
+        key: steam-runtime-${{ github.event.inputs.steamrt_snapshot }}
     - name: Download steam-runtime
       if: startsWith(matrix.os, 'ubuntu') && steps.cache-steam-runtime.outputs.cache-hit != 'true'
-      run: wget --no-verbose https://repo.steampowered.com/steamrt-images-scout/snapshots/0.20210610.0/com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
+      run: wget --no-verbose https://repo.steampowered.com/steamrt-images-scout/snapshots/${{ github.event.inputs.steamrt_snapshot }}/com.valvesoftware.SteamRuntime.Sdk-i386-scout-sysroot.tar.gz
     - name: Install steam runtime
       if: startsWith(matrix.os, 'ubuntu')
       run: |


### PR DESCRIPTION
I noticed the steam scout runtime sdk from 2021 is not available anymore. Valve probably deleted old archives. Try using latest-public-beta instead.

If you're interested here's the list of snapshots: https://repo.steampowered.com/steamrt-images-scout/snapshots/