### PR TITLE
Fix choosing the earth target for trigger_xen_return

### DIFF
--- a/dlls/gearbox/displacer.cpp
+++ b/dlls/gearbox/displacer.cpp
@@ -572,7 +572,7 @@ void CDisplacer::Teleport( void )
 	if( pTarget )
 		tmp = pTarget->pev->origin;
 
-	if( pTarget && /*HACK*/( tmp != Vector( 0, 0, 0 )/*HACK*/ ) )
+	if( pTarget )
 	{
 		if( (m_pPlayer->m_afPhysicsFlags & PFLAG_ONROPE) )
 			m_pPlayer->LetGoRope();
@@ -592,6 +592,7 @@ void CDisplacer::Teleport( void )
 		tmp.z+=37;
 
 		m_pPlayer->pev->flags &= ~FL_ONGROUND;
+		m_pPlayer->m_DisplacerReturn = m_pPlayer->pev->origin;
 
 		UTIL_SetOrigin(m_pPlayer->pev, tmp);
 

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -120,6 +120,7 @@ TYPEDESCRIPTION	CBasePlayer::m_playerSaveData[] =
 	DEFINE_FIELD( CBasePlayer, m_iFOV, FIELD_INTEGER ),
 
 	DEFINE_FIELD(CBasePlayer, m_fInXen, FIELD_BOOLEAN),
+	DEFINE_FIELD(CBasePlayer, m_DisplacerReturn, FIELD_VECTOR),
 	DEFINE_FIELD(CBasePlayer, m_pRope, FIELD_CLASSPTR),
 
 	//DEFINE_FIELD( CBasePlayer, m_fDeadTime, FIELD_FLOAT ), // only used in multiplayer games

--- a/dlls/player.h
+++ b/dlls/player.h
@@ -340,6 +340,7 @@ public:
 	// Op4 player attributes.
 	//
 	BOOL	m_fInXen;
+	Vector m_DisplacerReturn;
 
 	friend class CDisplacer;
 	friend class CTriggerXenReturn;


### PR DESCRIPTION
In Opposing Force the target to travel back to Earth is the one closest to the player's origin before he travelled to Xen.