### PR TITLE
Delete .lib files before uploading artifact for Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,13 @@ jobs:
       shell: bash
       run: echo "gamedir=$(grep build/CMakeCache.txt -Ee 'GAMEDIR:STRING=[a-z]+' | cut -d '=' -f 2)" >> $GITHUB_OUTPUT
       id: extract_gamedir
+    - name: Delete .lib files from dist
+      if: startsWith(matrix.os, 'windows')
+      run: |
+        Remove-Item -Force -Path dist/${{ steps.extract_gamedir.outputs.gamedir }}/cl_dlls/client.lib
+        Remove-Item -Force -Path dist/${{ steps.extract_gamedir.outputs.gamedir }}/dlls/*.lib
+        Remove-Item -Force -Path dist-vgui/${{ steps.extract_gamedir.outputs.gamedir }}/cl_dlls/client.lib
+        Remove-Item -Force -Path dist-vgui/${{ steps.extract_gamedir.outputs.gamedir }}/dlls/*.lib
     - name: Upload linux artifact
       if: startsWith(matrix.os, 'ubuntu') && matrix.cc == 'gcc'
       uses: actions/upload-artifact@v4

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -102,7 +102,7 @@ jobs:
       if: startsWith(matrix.os, 'windows')
       run: |
         Remove-Item -Force -Path dist/${{ steps.extract_gamedir.outputs.gamedir }}/cl_dlls/client.lib
-        Remove-Item -Force -Path dist/${{ steps.extract_gamedir.outputs.gamedir }}/dlls/hl.lib
+        Remove-Item -Force -Path dist/${{ steps.extract_gamedir.outputs.gamedir }}/dlls/*.lib
     - name: Upload linux artifact
       if: startsWith(matrix.os, 'ubuntu')
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fix #486 

This also changes deleting `dlls/hl.lib` to deleting `dlls/*.lib` in manual build to deal with cases when server dll is not `hl` (e.g. `opfor`). Of course I could instead extract the `SERVER_LIBRARY_NAME` from cmake, but it's easier this way.