### PR TITLE
Don't turn off the flashlight when removing weapons with player_weaponstrip

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -860,7 +860,8 @@ void CBasePlayer::RemoveAllItems( BOOL removeSuit )
 		pev->weapons &= ~WEAPON_ALLWEAPONS;
 
 	// Turn off flashlight
-	ClearBits( pev->effects, EF_DIMLIGHT );
+	if (removeSuit)
+		ClearBits( pev->effects, EF_DIMLIGHT );
 
 	for( i = 0; i < MAX_AMMO_SLOTS; i++ )
 		m_rgAmmo[i] = 0;


### PR DESCRIPTION
[This commit](https://github.com/FWGS/hlsdk-portable/commit/4d7d6f2c378f0b79fe9dd4eeb931cdb6daadd48f) introduced a change which turns off the flashlight in `RemoveAllItems`

I guess it was done so in order to turn off the flashlight in multiplayer when player dies.

This however interferes with how the `player_weaponstrip` works which also calls `RemoveAllItems`. In original Half-Life it doesn't turn off the flashlight.

As a middleground I think the flashlight should be turned off if the player is stripped of the suit (which happens in multiplayer via `PackDeadPlayerItems`)