### PR TITLE
Fix crossbow bolts

### DIFF
--- a/dlls/crossbow.cpp
+++ b/dlls/crossbow.cpp
@@ -156,7 +156,7 @@ void CCrossbowBolt::BoltTouch( CBaseEntity *pOther )
 			pev->angles.z = RANDOM_LONG( 0, 360 );
 			pev->nextthink = gpGlobals->time + 10.0f;
 		}
-		else if( pOther->pev->movetype == MOVETYPE_PUSH || pOther->pev->movetype == MOVETYPE_PUSHSTEP )
+		else if( g_fIsXash3D && (pOther->pev->movetype == MOVETYPE_PUSH || pOther->pev->movetype == MOVETYPE_PUSHSTEP) )
 		{
 			Vector vecDir = pev->velocity.Normalize();
 			UTIL_SetOrigin( pev, pev->origin - vecDir * 12.0f );
@@ -167,12 +167,9 @@ void CCrossbowBolt::BoltTouch( CBaseEntity *pOther )
 			pev->angles.z = RANDOM_LONG( 0, 360 );
 			pev->nextthink = gpGlobals->time + 10.0f;			
 
-			if( g_fIsXash3D )
-			{
-				// g-cont. Setup movewith feature
-				pev->movetype = MOVETYPE_COMPOUND;	// set movewith type
-				pev->aiment = ENT( pOther->pev );	// set parent
-			}
+			// g-cont. Setup movewith feature
+			pev->movetype = MOVETYPE_COMPOUND;	// set movewith type
+			pev->aiment = ENT( pOther->pev );	// set parent
 		}
 
 		if( UTIL_PointContents( pev->origin ) != CONTENTS_WATER )


### PR DESCRIPTION
Turned out the whole `else if` branch is Xash3D-specific, not just the lines with `MOVETYPE_COMPOUND`.

In Half-Life there's no special code to handle the brush entities - only worldspawn. Crossbow bolts do push func_pushables and they don't stay on brush entities to avoid situations when the entity moves and the bolt stays in place (e.g. if func_pushable moves or func_tank rotates).

In custom hlsdk for Xash3D bolts stay on brush entities and use `MOVETYPE_COMPOUND` to properly move with an entity, but don't push func_pushables.

In our sdk we got a mix of both: bolts stay when hitting brush entities, but as we avoid using `MOVETYPE_COMPOUND` on GoldSource, they might end up seemingly in the air.

I have rewritten the code so the Xash3D-specific behavior doesn't affect when running game libraries on GoldSource at all.

But honestly I think we should respect the original behavior on both engines and make Xash3D-specific behavior as option or remove it completely. What do you think?