### PR TITLE
Fix handgrenade damage hardcoded as 100

### DIFF
--- a/dlls/ggrenade.cpp
+++ b/dlls/ggrenade.cpp
@@ -425,7 +425,7 @@ CGrenade *CGrenade::ShootTimed( entvars_t *pevOwner, Vector vecStart, Vector vec
 	pGrenade->pev->gravity = 0.5f;
 	pGrenade->pev->friction = 0.8f;
 
-	pGrenade->pev->dmg = 100;
+	pGrenade->pev->dmg = gSkillData.plrDmgHandGrenade;
 
 	return pGrenade;
 }


### PR DESCRIPTION
Turned out the handgrenade damage value is hardcoded to 100 and doesn't use the `sk_plr_hand_grenade` skill value.

This bug exists in the original Half-Life and I didn't find an issue on that matter on Valve's bugtracker.