### PR TITLE
Fix crowbar applying breakable glass decals to unbreakable pushable objects

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -792,6 +792,8 @@ public:
 	// breakables use an overridden takedamage
 	virtual int TakeDamage( entvars_t *pevInflictor, entvars_t *pevAttacker, float flDamage, int bitsDamageType );
 
+	int DamageDecal(int bitsDamageType);
+
 	static TYPEDESCRIPTION m_SaveData[];
 
 	static const char *m_soundNames[3];
@@ -1043,4 +1045,12 @@ int CPushable::TakeDamage( entvars_t *pevInflictor, entvars_t *pevAttacker, floa
 		return CBreakable::TakeDamage( pevInflictor, pevAttacker, flDamage, bitsDamageType );
 
 	return 1;
+}
+
+int CPushable::DamageDecal(int bitsDamageType)
+{
+	if (FBitSet(pev->spawnflags, SF_PUSH_BREAKABLE))
+		return CBreakable::DamageDecal(bitsDamageType);
+
+	return CBaseEntity::DamageDecal(bitsDamageType);
 }


### PR DESCRIPTION
Same as https://github.com/twhl-community/halflife-updated/pull/219

Note that `DamageDecal` is a virtual function which means this change affects the CPushable's vtable.