### PR TITLE
Floor taken damage for player instead casting to int

### DIFF
--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -486,7 +486,7 @@ int CBasePlayer::TakeDamage( entvars_t *pevInflictor, entvars_t *pevAttacker, fl
 
 	// this cast to INT is critical!!! If a player ends up with 0.5 health, the engine will get that
 	// as an int (zero) and think the player is dead! (this will incite a clientside screentilt, etc)
-	fTookDamage = CBaseMonster::TakeDamage( pevInflictor, pevAttacker, (int)flDamage, bitsDamageType );
+	fTookDamage = CBaseMonster::TakeDamage( pevInflictor, pevAttacker, flDamage >= 0.0f ? floor(flDamage) : ceil(flDamage), bitsDamageType );
 
 	// reset damage time countdown for each type of time based damage player just sustained
 	{


### PR DESCRIPTION
Straight casting from `float` to `int` may result in the number becoming negative when the original number is positive if original `float` number is too large to be represented in `int`.

Example: the map `semonz` (distributed with Adrenaline Gamer mod) has several instances `trigger_hurt` with damage set to `"10000000000"` which can't be represented in `int`. It becomes negative which leads to increasing health in `TakeDamage`. Then in `V_CalcViewRoll` on client `pparams->health` becomes negative (probably some other cast in the chain?). Player continues to be considered alive by the server, but he has a rolled camera because the view code thinks the player is dead.

Note: ideally the `trunc` should be used instead of `floor` for positive values and `ceil` for negative ones. But it's C++11 and this repo is still C++98.