### PR TITLE
Fix reading links when the graph version is different from retail

### DIFF
--- a/dlls/nodes.cpp
+++ b/dlls/nodes.cpp
@@ -2475,7 +2475,10 @@ int CGraph::FLoadGraph( const char *szMapName )
 			length -= sizeof(CLink_Retail) * m_cLinks;
 			if( length < 0 )
 				goto ShortFile;
-			reinterpret_cast<CLink_Retail*>(pMemFile) -> copyOverTo(m_pLinkPool);
+			for (int j = 0; j < m_cLinks; ++j)
+			{
+				reinterpret_cast<CLink_Retail*>(pMemFile + sizeof(CLink_Retail) * j) -> copyOverTo(m_pLinkPool + j);
+			}
 			pMemFile += sizeof(CLink_Retail) * m_cLinks;
 		}
 #endif


### PR DESCRIPTION
Only first element has been copied over. Need a loop here.