### PR TITLE
Fix factor in func_pushable

### DIFF
--- a/dlls/func_break.cpp
+++ b/dlls/func_break.cpp
@@ -978,7 +978,6 @@ void CPushable::Move( CBaseEntity *pOther, int push )
 	{ 
 		if( push )
 		{
-			factor = 0.25f;
 			pev->velocity.x += pevToucher->velocity.x * factor;
 			pev->velocity.y += pevToucher->velocity.y * factor;
 		}


### PR DESCRIPTION
Fix incorrect set of factor that led to player being unable to push crates while crouching. Pushing wasn't true to anniversary version in general.