### PR TITLE
Fix alien grunt tracer effect end position

### DIFF
--- a/dlls/agrunt.cpp
+++ b/dlls/agrunt.cpp
@@ -233,15 +233,17 @@ void CAGrunt::TraceAttack( entvars_t *pevAttacker, float flDamage, Vector vecDir
 
 			vecTracerDir = vecTracerDir * -512.0f;
 
+			Vector vecTracerEnd = ptr->vecEndPos + vecTracerDir;
+
 			MESSAGE_BEGIN( MSG_PVS, SVC_TEMPENTITY, ptr->vecEndPos );
 			WRITE_BYTE( TE_TRACER );
 				WRITE_COORD( ptr->vecEndPos.x );
 				WRITE_COORD( ptr->vecEndPos.y );
 				WRITE_COORD( ptr->vecEndPos.z );
 
-				WRITE_COORD( vecTracerDir.x );
-				WRITE_COORD( vecTracerDir.y );
-				WRITE_COORD( vecTracerDir.z );
+				WRITE_COORD( vecTracerEnd.x );
+				WRITE_COORD( vecTracerEnd.y );
+				WRITE_COORD( vecTracerEnd.z );
 			MESSAGE_END();
 		}
 


### PR DESCRIPTION
The problem:
Alien grunt code sends the direction vector as the second vector in TE_TRACER message. But the message expects both vectors to represent positions.

This explains random tracers you could see while being near the world origin when alien grunts fight human grunts.

The test map to reproduce the issue on vanilla Half-Life: [agrunt_test.zip](https://github.com/user-attachments/files/19734530/agrunt_test.zip)