### PR TITLE
Use windows-latest in github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,17 +71,17 @@ jobs:
     - name: Build on Windows
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 17 2022" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist"
+        cmake -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist"
         msbuild -verbosity:normal /property:Configuration=Release build/INSTALL.vcxproj
     - name: Build on Windows x64
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 17 2022" -A x64 -B build64 -DCMAKE_INSTALL_PREFIX="dist64" -D64BIT=ON
+        cmake -A x64 -B build64 -DCMAKE_INSTALL_PREFIX="dist64" -D64BIT=ON
         msbuild -verbosity:normal /property:Configuration=Release /property:Platform=x64 build64/INSTALL.vcxproj
     - name: Build on Windows with vgui
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 17 2022" -A Win32 -B build -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="dist-vgui"
+        cmake -A Win32 -B build -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="dist-vgui"
         msbuild -verbosity:normal /property:Configuration=Release build/INSTALL.vcxproj
 
     - name: Extract branch name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
           - os: ubuntu-latest
             cc: clang
             cxx: clang++
-          - os: windows-2019
+          - os: windows-latest
             cc: cl
             cxx: cl
     env:
@@ -71,17 +71,17 @@ jobs:
     - name: Build on Windows
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist"
+        cmake -G "Visual Studio 17 2022" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist"
         msbuild -verbosity:normal /property:Configuration=Release build/INSTALL.vcxproj
     - name: Build on Windows x64
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 16 2019" -A x64 -B build64 -DCMAKE_INSTALL_PREFIX="dist64" -D64BIT=ON
+        cmake -G "Visual Studio 17 2022" -A x64 -B build64 -DCMAKE_INSTALL_PREFIX="dist64" -D64BIT=ON
         msbuild -verbosity:normal /property:Configuration=Release /property:Platform=x64 build64/INSTALL.vcxproj
     - name: Build on Windows with vgui
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="dist-vgui"
+        cmake -G "Visual Studio 17 2022" -A Win32 -B build -DUSE_VGUI=ON -DCMAKE_INSTALL_PREFIX="dist-vgui"
         msbuild -verbosity:normal /property:Configuration=Release build/INSTALL.vcxproj
 
     - name: Extract branch name

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,7 +28,7 @@ jobs:
           - os: ubuntu-latest
             cc: gcc
             cxx: g++
-          - os: windows-2019
+          - os: windows-latest
             cc: cl
             cxx: cl
     env:
@@ -82,7 +82,7 @@ jobs:
     - name: Build on Windows
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 16 2019" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist" -DUSE_VGUI=${{ github.event.inputs.usevgui }}
+        cmake -G "Visual Studio 17 2022" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist" -DUSE_VGUI=${{ github.event.inputs.usevgui }}
         msbuild -verbosity:normal /property:Configuration=${{ github.event.inputs.buildtype }} build/INSTALL.vcxproj
 
     - name: Extract branch name

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Build on Windows
       if: startsWith(matrix.os, 'windows')
       run: |
-        cmake -G "Visual Studio 17 2022" -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist" -DUSE_VGUI=${{ github.event.inputs.usevgui }}
+        cmake -A Win32 -B build -DCMAKE_INSTALL_PREFIX="dist" -DUSE_VGUI=${{ github.event.inputs.usevgui }}
         msbuild -verbosity:normal /property:Configuration=${{ github.event.inputs.buildtype }} build/INSTALL.vcxproj
 
     - name: Extract branch name


### PR DESCRIPTION
Windows 2019 runner will be removed soon https://github.com/actions/runner-images/issues/12045

I set windows-latest and also removed specifying the Visual Studio generator to avoid having to modify it each time the visual studio version is changed in the runner (e.g. windows-latest doesn't have Visual Studio 16 2019).

I don't know if produced binaries still work on older Windows (7 and 8.1). Someone will need to check it if it's important.