### PR TITLE
Fix crash when switching weapons when hand grenades are used up.

### DIFF
--- a/dlls/handgrenade.cpp
+++ b/dlls/handgrenade.cpp
@@ -99,7 +99,8 @@ void CHandGrenade::Holster( int skiplocal /* = 0 */ )
 	{
 		// no more grenades!
 		m_pPlayer->pev->weapons &= ~( 1 << WEAPON_HANDGRENADE );
-		DestroyItem();
+		SetThink( &CHandGrenade::DestroyItem );
+		pev->nextthink = gpGlobals->time + 0.1;
 	}
 
 	if( m_flStartThrow )


### PR DESCRIPTION
Currently, when hand grenades are used up, crash will happen if user switches to another weapon:

```
#261654 0x00007f5a20962aae in CBasePlayer::RemovePlayerItem (this=0x20075e98, pItem=0x20076888, bCallHolster=<optimized out>) at ../dlls/player.cpp:4069
#261655 0x00007f5a209a8862 in CBasePlayerItem::DestroyItem (this=this@entry=0x20076888) at ../dlls/weapons.cpp:731
#261656 0x00007f5a2091955e in CHandGrenade::Holster (this=0x20076888, skiplocal=<optimized out>) at ../dlls/handgrenade.cpp:102
#261657 0x00007f5a20962aae in CBasePlayer::RemovePlayerItem (this=0x20075e98, pItem=0x20076888, bCallHolster=<optimized out>) at ../dlls/player.cpp:4069
#261658 0x00007f5a209a8862 in CBasePlayerItem::DestroyItem (this=this@entry=0x20076888) at ../dlls/weapons.cpp:731
#261659 0x00007f5a2091955e in CHandGrenade::Holster (this=0x20076888, skiplocal=<optimized out>) at ../dlls/handgrenade.cpp:102
#261660 0x00007f5a20962aae in CBasePlayer::RemovePlayerItem (this=0x20075e98, pItem=0x20076888, bCallHolster=<optimized out>) at ../dlls/player.cpp:4069
#261661 0x00007f5a209a8862 in CBasePlayerItem::DestroyItem (this=this@entry=0x20076888) at ../dlls/weapons.cpp:731
#261662 0x00007f5a2091955e in CHandGrenade::Holster (this=0x20076888, skiplocal=<optimized out>) at ../dlls/handgrenade.cpp:102
#261663 0x00007f5a20962aae in CBasePlayer::RemovePlayerItem (this=0x20075e98, pItem=0x20076888, bCallHolster=<optimized out>) at ../dlls/player.cpp:4069
#261664 0x00007f5a209a8862 in CBasePlayerItem::DestroyItem (this=this@entry=0x20076888) at ../dlls/weapons.cpp:731
#261665 0x00007f5a2091955e in CHandGrenade::Holster (this=0x20076888, skiplocal=<optimized out>) at ../dlls/handgrenade.cpp:102
#261666 0x00007f5a20962aae in CBasePlayer::RemovePlayerItem (this=0x20075e98, pItem=0x20076888, bCallHolster=<optimized out>) at ../dlls/player.cpp:4069
#261667 0x00007f5a209a8862 in CBasePlayerItem::DestroyItem (this=this@entry=0x20076888) at ../dlls/weapons.cpp:731
#261668 0x00007f5a2091955e in CHandGrenade::Holster (this=0x20076888, skiplocal=<optimized out>) at ../dlls/handgrenade.cpp:102
#261669 0x00007f5a20962aae in CBasePlayer::RemovePlayerItem (this=0x20075e98, pItem=0x20076888, bCallHolster=<optimized out>) at ../dlls/player.cpp:4069
#261670 0x00007f5a209a8862 in CBasePlayerItem::DestroyItem (this=this@entry=0x20076888) at ../dlls/weapons.cpp:731
#261671 0x00007f5a2091955e in CHandGrenade::Holster (this=0x20076888, skiplocal=<optimized out>) at ../dlls/handgrenade.cpp:102
#261672 0x00007f5a20960eee in CBasePlayer::SelectItem (this=0x20075e98, pstr=0x1fbd14f8 "weapon_9mmAR") at ../dlls/player.cpp:3482
#261673 0x00007f5a243271e3 in SV_ExecuteClientMessage (cl=cl@entry=0x7f59f0ec6038, msg=msg@entry=0x7f5a247d86a0 <net_message>) at ../engine/server/sv_client.c:3637
#261674 0x00007f5a2433f071 in SV_ReadPackets () at ../engine/server/sv_main.c:422
#261675 Host_ServerFrame () at ../engine/server/sv_main.c:695
#261676 0x00007f5a242d9afc in Host_Frame (time=time@entry=0.01659868000001552) at ../engine/common/host.c:788
#261677 0x00007f5a242db6f0 in Host_RunFrame (time=0.01659868000001552) at ../engine/common/host_state.c:159
#261678 COM_Frame (time=0.01659868000001552) at ../engine/common/host_state.c:221
#261679 0x00007f5a242da9d7 in Host_Main (argc=5, argv=0x7ffe0d615ec8, progname=0x4070a0 <szGameDir> "valve", bChangeGame=0, func=0x400710 <Sys_ChangeGame(char const*)>) at ../engine/common/host.c:1340
#261680 0x0000000000400480 in Sys_Start () at ../game_launch/game.cpp:196
#261681 main (argc=<optimized out>, argv=<optimized out>) at ../game_launch/game.cpp:209
```

This fixes the issue.