### PR TITLE
Fix crash for satchel, squeak grenade, and tripmine.

### DIFF
--- a/dlls/satchel.cpp
+++ b/dlls/satchel.cpp
@@ -343,7 +343,8 @@ void CSatchel::Holster( int skiplocal /* = 0 */ )
 	if( !m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] && m_chargeReady != SATCHEL_READY )
 	{
 		m_pPlayer->pev->weapons &= ~( 1 << WEAPON_SATCHEL );
-		DestroyItem();
+		SetThink( &CSatchel::DestroyItem );
+		pev->nextthink = gpGlobals->time + 0.1;
 	}
 }
 

--- a/dlls/squeakgrenade.cpp
+++ b/dlls/squeakgrenade.cpp
@@ -483,7 +483,8 @@ void CSqueak::Holster( int skiplocal /* = 0 */ )
 	if( !m_pPlayer->m_rgAmmo[m_iPrimaryAmmoType] )
 	{
 		m_pPlayer->pev->weapons &= ~( 1 << WEAPON_SNARK );
-		DestroyItem();
+		SetThink( &CSqueak::DestroyItem );
+		pev->nextthink = gpGlobals->time + 0.1;
 		return;
 	}
 

--- a/dlls/tripmine.cpp
+++ b/dlls/tripmine.cpp
@@ -442,7 +442,8 @@ void CTripmine::Holster( int skiplocal /* = 0 */ )
 	{
 		// out of mines
 		m_pPlayer->pev->weapons &= ~( 1 << WEAPON_TRIPMINE );
-		DestroyItem();
+		SetThink( &CTripmine::DestroyItem );
+		pev->nextthink = gpGlobals->time + 0.1;
 	}
 
 	SendWeaponAnim( TRIPMINE_HOLSTER );


### PR DESCRIPTION
This is the same bug as PR #551.  It also exists for some other weapons.