### PR TITLE
Fix Xen Attack not working properly.

### DIFF
--- a/dlls/world.cpp
+++ b/dlls/world.cpp
@@ -455,7 +455,6 @@ BOOL  g_startSuit;          // When level starts player will automatically recei
 void CWorld::Spawn( void )
 {
 	g_fGameOver = FALSE;
-	m_bSlaveCoop = false;
 	Precache();
 }
 


### PR DESCRIPTION
The root cause is m_bSlaveCoop was set in CWorld::KeyValue but got immediately resetted in CWorld::Spawn.  This fixes the issue.