### PR TITLE
client: restore TriAPI rendermode after overview rendering

### DIFF
--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -1470,6 +1470,7 @@ void CHudSpectator::DrawOverviewLayer()
 					gEngfuncs.pTriAPI->TexCoord2f( 0, 1 );
 					gEngfuncs.pTriAPI->Vertex3f( x, y + yStep, z);
 				gEngfuncs.pTriAPI->End();
+				gEngfuncs.pTriAPI->RenderMode( kRenderNormal );
 
 				frame++;
 				x += xStep;
@@ -1509,6 +1510,7 @@ void CHudSpectator::DrawOverviewLayer()
 					gEngfuncs.pTriAPI->TexCoord2f( 1, 0 );
 					gEngfuncs.pTriAPI->Vertex3f( x, y + yStep, z );
 				gEngfuncs.pTriAPI->End();
+				gEngfuncs.pTriAPI->RenderMode( kRenderNormal );
 
 				frame++;
 
@@ -1711,6 +1713,7 @@ void CHudSpectator::DrawOverviewEntities()
 		gEngfuncs.pTriAPI->TexCoord2f( 1.0f, 1.0f );
 		gEngfuncs.pTriAPI->Vertex3f( x + left[0], y + left[1], ( z + left[2] ) * zScale );
 	gEngfuncs.pTriAPI->End ();
+	gEngfuncs.pTriAPI->RenderMode( kRenderNormal );
 }
 
 void CHudSpectator::DrawOverview()


### PR DESCRIPTION
Fixes: https://github.com/FWGS/xash3d-fwgs/issues/2080 and https://github.com/FWGS/xash3d-fwgs/issues/960

TriAPI render mode was not restored after rendering the main overview layer/entities, causing the state to leak into the inset view (a.k.a. Picture-in-Picture). This resulted in incorrect geometry rendering (invisible walls, objects drawing through each other) and broken lighting that looked like fullbright rendering.

The official Valve's HLSDK restores the TriAPI render mode, see here:
https://github.com/ValveSoftware/halflife/blob/b1b5cf5892918535619b2937bb927e46cb097ba1/cl_dll/overview.cpp#L139