### PR TITLE
counter-life: client: Add missing files to CMakeLists.txt

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -105,6 +105,7 @@ set (CLDLL_SOURCES
 	ammo.cpp
 	ammo_secondary.cpp
 	ammohistory.cpp
+	bank.cpp
 	battery.cpp
 	cdll_int.cpp
 	com_weapons.cpp
@@ -135,6 +136,7 @@ set (CLDLL_SOURCES
 	../pm_shared/pm_math.c
 	../pm_shared/pm_shared.c
 	saytext.cpp
+	shroud.cpp
 	status_icons.cpp
 	statusbar.cpp
 	studio_util.cpp


### PR DESCRIPTION
The CMakeLists.txt in cl_dll was missing two .cpp files: `shroud.cpp` and `bank.cpp`. Because of that, the repository couldn't compile because some files used functions from `shroud.cpp` and you couldn't see your money because it is a part of `bank.cpp` code. This PR adds those files to CMakeLists.txt sources list