### PR TITLE
Add missing keyword case.

### DIFF
--- a/dlls/lights.cpp
+++ b/dlls/lights.cpp
@@ -328,7 +328,7 @@ void CLight::Use( CBaseEntity *pActivator, CBaseEntity *pCaller, USE_TYPE useTyp
 		else
 				m_iState = STATE_ON;
 			break;
-		STATE_IN_USE:
+		case STATE_IN_USE:
 			break;
 		default:
 			break;


### PR DESCRIPTION
Target branch: [sohl1.2](https://github.com/FWGS/hlsdk-portable/tree/sohl1.2)

This fixes `warning C4102: 'STATE_IN_USE': unreferenced label` during compilation.

Tested both in Debug and Release.