### PR TITLE
Remove unreferenced local variable.

### DIFF
--- a/dlls/nodes.cpp
+++ b/dlls/nodes.cpp
@@ -219,7 +219,6 @@ entvars_t *CGraph::LinkEntForLink( CLink *pLink, CNode *pNode )
 //=========================================================
 int CGraph::HandleLinkEnt( int iNode, entvars_t *pevLinkEnt, int afCapMask, NODEQUERY queryType )
 {
-	edict_t  *pentWorld;
 	//edict_t *pentWorld;
 	CBaseEntity *pDoor;
 	TraceResult tr;


### PR DESCRIPTION
Target branch: [sohl1.2](https://github.com/FWGS/hlsdk-portable/tree/sohl1.2)

This fixes `warning C4101: 'pentWorld': unreferenced local variable` during compilation.

The next line that's commented is already commented in [master](https://github.com/FWGS/hlsdk-portable/blob/8c5b2846c2448e2b063f358f041d565dc0f076b1/dlls/nodes.cpp#L220). 

Tested both in Debug and Release.