### PR TITLE
DMC/ThreeWave: Fix not showing the ammo HUD

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -621,7 +621,7 @@ int CHudAmmo::MsgFunc_WeaponList( const char *pszName, int iSize, void *pbuf )
 	if( Weapon.iMax1 == 255 )
 		Weapon.iMax1 = -1;
 
-	Weapon.iAmmo2Type = READ_BYTE();
+	Weapon.iAmmo2Type = READ_CHAR();
 	Weapon.iMax2 = READ_BYTE();
 	if( Weapon.iMax2 == 255 )
 		Weapon.iMax2 = -1;


### PR DESCRIPTION
The code wasn't properly updated after hl25 anniversary update, so the latter check prevented the item from adding to HUD.

https://github.com/ValveSoftware/halflife/blob/b1b5cf5892918535619b2937bb927e46cb097ba1/dmc/cl_dll/ammo.cpp#L623