### PR TITLE
Replace copyright symbol with (c) in vgui headers

### DIFF
--- a/utils/vgui/include/VGUI.h
+++ b/utils/vgui/include/VGUI.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ActionSignal.h
+++ b/utils/vgui/include/VGUI_ActionSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_App.h
+++ b/utils/vgui/include/VGUI_App.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Bitmap.h
+++ b/utils/vgui/include/VGUI_Bitmap.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_BitmapTGA.h
+++ b/utils/vgui/include/VGUI_BitmapTGA.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Border.h
+++ b/utils/vgui/include/VGUI_Border.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_BorderLayout.h
+++ b/utils/vgui/include/VGUI_BorderLayout.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_BorderPair.h
+++ b/utils/vgui/include/VGUI_BorderPair.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_BuildGroup.h
+++ b/utils/vgui/include/VGUI_BuildGroup.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Button.h
+++ b/utils/vgui/include/VGUI_Button.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ButtonController.h
+++ b/utils/vgui/include/VGUI_ButtonController.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ButtonGroup.h
+++ b/utils/vgui/include/VGUI_ButtonGroup.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ChangeSignal.h
+++ b/utils/vgui/include/VGUI_ChangeSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_CheckButton.h
+++ b/utils/vgui/include/VGUI_CheckButton.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Color.h
+++ b/utils/vgui/include/VGUI_Color.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ComboKey.h
+++ b/utils/vgui/include/VGUI_ComboKey.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ConfigWizard.h
+++ b/utils/vgui/include/VGUI_ConfigWizard.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Cursor.h
+++ b/utils/vgui/include/VGUI_Cursor.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Dar.h
+++ b/utils/vgui/include/VGUI_Dar.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_DataInputStream.h
+++ b/utils/vgui/include/VGUI_DataInputStream.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Desktop.h
+++ b/utils/vgui/include/VGUI_Desktop.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_DesktopIcon.h
+++ b/utils/vgui/include/VGUI_DesktopIcon.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_EditPanel.h
+++ b/utils/vgui/include/VGUI_EditPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_EtchedBorder.h
+++ b/utils/vgui/include/VGUI_EtchedBorder.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_FileInputStream.h
+++ b/utils/vgui/include/VGUI_FileInputStream.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_FlowLayout.h
+++ b/utils/vgui/include/VGUI_FlowLayout.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_FocusChangeSignal.h
+++ b/utils/vgui/include/VGUI_FocusChangeSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_FocusNavGroup.h
+++ b/utils/vgui/include/VGUI_FocusNavGroup.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Font.h
+++ b/utils/vgui/include/VGUI_Font.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Frame.h
+++ b/utils/vgui/include/VGUI_Frame.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_FrameSignal.h
+++ b/utils/vgui/include/VGUI_FrameSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_GridLayout.h
+++ b/utils/vgui/include/VGUI_GridLayout.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_HeaderPanel.h
+++ b/utils/vgui/include/VGUI_HeaderPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Image.h
+++ b/utils/vgui/include/VGUI_Image.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ImagePanel.h
+++ b/utils/vgui/include/VGUI_ImagePanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_InputSignal.h
+++ b/utils/vgui/include/VGUI_InputSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_InputStream.h
+++ b/utils/vgui/include/VGUI_InputStream.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_IntChangeSignal.h
+++ b/utils/vgui/include/VGUI_IntChangeSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_IntLabel.h
+++ b/utils/vgui/include/VGUI_IntLabel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_KeyCode.h
+++ b/utils/vgui/include/VGUI_KeyCode.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Label.h
+++ b/utils/vgui/include/VGUI_Label.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Layout.h
+++ b/utils/vgui/include/VGUI_Layout.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_LayoutInfo.h
+++ b/utils/vgui/include/VGUI_LayoutInfo.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_LineBorder.h
+++ b/utils/vgui/include/VGUI_LineBorder.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ListPanel.h
+++ b/utils/vgui/include/VGUI_ListPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_LoweredBorder.h
+++ b/utils/vgui/include/VGUI_LoweredBorder.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Menu.h
+++ b/utils/vgui/include/VGUI_Menu.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_MenuItem.h
+++ b/utils/vgui/include/VGUI_MenuItem.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_MenuSeparator.h
+++ b/utils/vgui/include/VGUI_MenuSeparator.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_MessageBox.h
+++ b/utils/vgui/include/VGUI_MessageBox.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_MiniApp.h
+++ b/utils/vgui/include/VGUI_MiniApp.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_MouseCode.h
+++ b/utils/vgui/include/VGUI_MouseCode.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Panel.h
+++ b/utils/vgui/include/VGUI_Panel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Point.h
+++ b/utils/vgui/include/VGUI_Point.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2001, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2001, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_PopupMenu.h
+++ b/utils/vgui/include/VGUI_PopupMenu.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ProgressBar.h
+++ b/utils/vgui/include/VGUI_ProgressBar.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_RadioButton.h
+++ b/utils/vgui/include/VGUI_RadioButton.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_RaisedBorder.h
+++ b/utils/vgui/include/VGUI_RaisedBorder.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_RepaintSignal.h
+++ b/utils/vgui/include/VGUI_RepaintSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Scheme.h
+++ b/utils/vgui/include/VGUI_Scheme.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ScrollBar.h
+++ b/utils/vgui/include/VGUI_ScrollBar.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ScrollPanel.h
+++ b/utils/vgui/include/VGUI_ScrollPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Slider.h
+++ b/utils/vgui/include/VGUI_Slider.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_StackLayout.h
+++ b/utils/vgui/include/VGUI_StackLayout.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_String.h
+++ b/utils/vgui/include/VGUI_String.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_Surface.h
+++ b/utils/vgui/include/VGUI_Surface.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_SurfaceBase.h
+++ b/utils/vgui/include/VGUI_SurfaceBase.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_SurfaceGL.h
+++ b/utils/vgui/include/VGUI_SurfaceGL.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TabPanel.h
+++ b/utils/vgui/include/VGUI_TabPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TablePanel.h
+++ b/utils/vgui/include/VGUI_TablePanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TaskBar.h
+++ b/utils/vgui/include/VGUI_TaskBar.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TextEntry.h
+++ b/utils/vgui/include/VGUI_TextEntry.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TextGrid.h
+++ b/utils/vgui/include/VGUI_TextGrid.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TextImage.h
+++ b/utils/vgui/include/VGUI_TextImage.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TextPanel.h
+++ b/utils/vgui/include/VGUI_TextPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TickSignal.h
+++ b/utils/vgui/include/VGUI_TickSignal.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_ToggleButton.h
+++ b/utils/vgui/include/VGUI_ToggleButton.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_TreeFolder.h
+++ b/utils/vgui/include/VGUI_TreeFolder.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //

--- a/utils/vgui/include/VGUI_WizardPanel.h
+++ b/utils/vgui/include/VGUI_WizardPanel.h
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright (c) 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //


### PR DESCRIPTION
The files include a copyright symbol in ISO-8859-15 encoding. Change it to `(c)` to make files ASCII compatible. Some text editors have troubles autodetecting the ISO encoding.