### PR TITLE
Use local sdl2 headers on Linux as well

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -162,7 +162,7 @@ endif()
 
 include_directories (. hl/ ../dlls ../dlls/wpn_shared ../common ../engine ../pm_shared ../game_shared ../public)
 
-if (WIN32)
+if (GOLDSOURCE_SUPPORT)
 	include_directories (../external/)
 endif()
 


### PR DESCRIPTION
We already use local sdl2 headers (in external/ directory) on Windows. I rewrite it to include SDL2 from same location on all goldsource platforms (as currently it's used only in the GoldSource mouse/joystick input code).