### PR TITLE
Fix ichthyosaur bumping into the walls sometimes

### DIFF
--- a/dlls/ichthyosaur.cpp
+++ b/dlls/ichthyosaur.cpp
@@ -958,10 +958,10 @@ void CIchthyosaur::Swim()
 
 	Vector f, u, l, r, d;
 	f = DoProbe( start + PROBE_LENGTH * Forward );
-	r = DoProbe( start + PROBE_LENGTH / 3 * Forward + Right );
-	l = DoProbe( start + PROBE_LENGTH / 3 * Forward - Right );
-	u = DoProbe( start + PROBE_LENGTH / 3 * Forward + Up );
-	d = DoProbe( start + PROBE_LENGTH / 3 * Forward - Up );
+	r = DoProbe( start + PROBE_LENGTH / 3 * (Forward + Right) );
+	l = DoProbe( start + PROBE_LENGTH / 3 * (Forward - Right) );
+	u = DoProbe( start + PROBE_LENGTH / 3 * (Forward + Up) );
+	d = DoProbe( start + PROBE_LENGTH / 3 * (Forward - Up) );
 
 	Vector SteeringVector = f + r + l + u + d;
 	m_SaveVelocity = ( m_SaveVelocity + SteeringVector / 2 ).Normalize();


### PR DESCRIPTION
The formula for `DoProbe` missed the parenthesis. This has been fixed in source sdk 
https://github.com/ValveSoftware/source-sdk-2013/blob/b8cfb12c0e083a2ef5b2f9f9b50f3902fa034474/src/game/server/hl2/npc_ichthyosaur.cpp#L650-L653

Also in HL Source code:

```c++
	r = DoProbe(vStart + ((PROBE_LENGTH/3) * (vForward + vRight)) );
	l = DoProbe(vStart + ((PROBE_LENGTH/3) * (vForward - vRight)) );	
	u = DoProbe(vStart + ((PROBE_LENGTH/3) * (vForward + vUp)) );
	d = DoProbe(vStart + ((PROBE_LENGTH/3) * (vForward - vUp)) );
```