### PR TITLE
Fix Apache and Osprey sometimes not crashing

### DIFF
--- a/dlls/apache.cpp
+++ b/dlls/apache.cpp
@@ -417,11 +417,17 @@ void CApache::FlyTouch( CBaseEntity *pOther )
 void CApache::CrashTouch( CBaseEntity *pOther )
 {
 	// only crash if we hit something solid
-	if( pOther->pev->solid == SOLID_BSP )
+	switch(pOther->pev->solid)
 	{
+	case SOLID_BBOX:
+	case SOLID_SLIDEBOX:
+	case SOLID_BSP:
 		SetTouch( NULL );
 		m_flNextRocket = gpGlobals->time;
 		pev->nextthink = gpGlobals->time;
+		break;
+	default:
+		break;
 	}
 }
 

--- a/dlls/osprey.cpp
+++ b/dlls/osprey.cpp
@@ -519,12 +519,18 @@ void COsprey::Killed( entvars_t *pevAttacker, int iGib )
 void COsprey::CrashTouch( CBaseEntity *pOther )
 {
 	// only crash if we hit something solid
-	if( pOther->pev->solid == SOLID_BSP )
+	switch(pOther->pev->solid)
 	{
+	case SOLID_BBOX:
+	case SOLID_SLIDEBOX:
+	case SOLID_BSP:
 		SetTouch( NULL );
 		m_startTime = gpGlobals->time;
 		pev->nextthink = gpGlobals->time;
 		m_velocity = pev->velocity;
+		break;
+	default:
+		break;
 	}
 }
 


### PR DESCRIPTION
If falling Apache or Osprey lands on something else besides `SOLID_BSP` (e.g. a monster or pushable) it will stuck, not finishing the crash.

This particular fix might be questionable as projectiles use `SOLID_BBOX` as well, and the interaction between a projectile and falling aircraft should probably be something else than immediatelly crashing, but I'm not sure.