### PR TITLE
Don't draw zoom crosshairs when unscoped if default_fov is less than 90

### DIFF
--- a/cl_dll/ammo.cpp
+++ b/cl_dll/ammo.cpp
@@ -612,7 +612,7 @@ int CHudAmmo::MsgFunc_CurWeapon( const char *pszName, int iSize, void *pbuf )
 
 	if( !( gHUD.m_iHideHUDDisplay & ( HIDEHUD_WEAPONS | HIDEHUD_ALL ) ) )
 	{
-		if( gHUD.m_iFOV >= 90 )
+		if( !gHUD.m_inScope )
 		{
 			// normal crosshairs
 			if( fOnTarget && m_pWeapon->hAutoaim )

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -335,6 +335,7 @@ void CHud::Init( void )
 
 	m_iLogo = 0;
 	m_iFOV = 0;
+	m_inScope = false;
 
 	CVAR_CREATE( "zoom_sensitivity_ratio", "1.2", FCVAR_ARCHIVE );
 	CVAR_CREATE( "cl_autowepswitch", "1", FCVAR_ARCHIVE | FCVAR_USERINFO );
@@ -686,9 +687,11 @@ int CHud::MsgFunc_SetFOV( const char *pszName,  int iSize, void *pbuf )
 	BEGIN_READ( pbuf, iSize );
 
 	int newfov = READ_BYTE();
-	int def_fov = CVAR_GET_FLOAT( "default_fov" );
+	int def_fov = default_fov->value;
 
 	g_lastFOV = newfov;
+
+	m_inScope = newfov != 0;
 
 	if( newfov == 0 )
 	{

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -641,6 +641,7 @@ public:
 	int	m_iWeaponBits;
 	int	m_fPlayerDead;
 	int m_iIntermission;
+	bool m_inScope;
 
 	// sprite indexes
 	int m_HUD_number_0;

--- a/cl_dll/hud_msg.cpp
+++ b/cl_dll/hud_msg.cpp
@@ -54,6 +54,7 @@ int CHud::MsgFunc_ResetHUD( const char *pszName, int iSize, void *pbuf )
 	// Vit_amiN: reset the FOV
 	m_iFOV = 0;	// default_fov
 	g_lastFOV = 0.0f;
+	m_inScope = false;
 
 	return 1;
 }


### PR DESCRIPTION
If you set default_fov to something less than 90 (e.g. 85), the weapons will show zoom crosshair even when unscoped.