### PR TITLE
Fix #526

### DIFF
--- a/dlls/observer.cpp
+++ b/dlls/observer.cpp
@@ -21,6 +21,7 @@
 #include	"player.h"
 #include	"weapons.h"
 #include	"pm_shared.h"
+#include	"gamerules.h"
 
 extern int gmsgCurWeapon;
 extern int gmsgSetFOV;
@@ -278,6 +279,7 @@ void CBasePlayer::StopObserver()
 	m_iHideHUD = 0;
 
 	GetClassPtr( (CBasePlayer *)pev )->Spawn();
+	g_pGameRules->SetDefaultPlayerTeam( this );
 	pev->nextthink = -1;
 
 	// Update Team Status

--- a/dlls/player.cpp
+++ b/dlls/player.cpp
@@ -1491,7 +1491,7 @@ void CBasePlayer::StartObserver( Vector vecPosition, Vector vecViewAngle )
 	// Clear out the status bar
 	m_fInitHUD = TRUE;
 
-	pev->team = 0;
+	m_szTeamName[0] = '\0';
 	MESSAGE_BEGIN( MSG_ALL, gmsgTeamInfo );
 		WRITE_BYTE( ENTINDEX(edict()) );
 		WRITE_STRING( "" );


### PR DESCRIPTION
When player joined spectators its `m_szTeamName` didn't get cleared, so in all further updates to other players except for the one that was made right in `StartObserver` the player still was considered as part of a team.

The solution is to clear the `m_szTeamName` in `StartObserver` and re-set the team again in the `StopObserver`.

I also removed `pev->team` assignment in `StartObserver`, because this parameter is not used by players. It's for a worldspawn and is stores the preferred list of teams for this map.