### PR TITLE
Fix spectator UI obscuring the non-vgui scoreboard

### DIFF
--- a/cl_dll/scoreboard.cpp
+++ b/cl_dll/scoreboard.cpp
@@ -30,6 +30,7 @@ cvar_t *cl_scoreboard_bg;
 cvar_t *cl_showpacketloss;
 
 #include "vgui_TeamFortressViewport.h"
+#include "vgui_SpectatorPanel.h"
 
 DECLARE_COMMAND( m_Scoreboard, ShowScores )
 DECLARE_COMMAND( m_Scoreboard, HideScores )
@@ -95,6 +96,17 @@ int SCOREBOARD_WIDTH = 320;
 #define ROW_GAP  (gHUD.m_scrinfo.iCharHeight)
 #define ROW_RANGE_MIN 15
 #define ROW_RANGE_MAX ( ScreenHeight - 50 )
+#define TOP_PADDING 5
+
+static int TopLevelGap()
+{
+	return g_iUser1 ? (YRES_HD(PANEL_HEIGHT) + TOP_PADDING) : ROW_RANGE_MIN;
+}
+
+static int ScoreboardHeight()
+{
+	return g_iUser1 ? (ScreenHeight - YRES_HD(PANEL_HEIGHT)*2) : ROW_RANGE_MAX;
+}
 
 int CHudScoreboard::Draw( float fTime )
 {
@@ -131,7 +143,7 @@ int CHudScoreboard::Draw( float fTime )
 	int xpos_rel = ( ScreenWidth - SCOREBOARD_WIDTH ) / 2;
 
 	// print the heading line
-	int ypos = ROW_RANGE_MIN + ( list_slot * ROW_GAP );
+	int ypos = TopLevelGap() + ( list_slot * ROW_GAP );
 	int xpos = NAME_RANGE_MIN + xpos_rel;
 
 	FAR_RIGHT = can_show_packetloss ? PL_RANGE_MAX : PING_RANGE_MAX;
@@ -144,7 +156,7 @@ int CHudScoreboard::Draw( float fTime )
 	}
 
 	if( cl_scoreboard_bg && cl_scoreboard_bg->value )
-		gHUD.DrawDarkRectangle( xpos - 5, ypos - 5, FAR_RIGHT, ROW_RANGE_MAX );
+		gHUD.DrawDarkRectangle( xpos - 5, ypos - TOP_PADDING, FAR_RIGHT, ScoreboardHeight() );
 	if( !gHUD.m_Teamplay )
 		DrawUtfString( xpos, ypos, NAME_RANGE_MAX + xpos_rel, "Player", 255, 140, 0 );
 	else
@@ -161,7 +173,7 @@ int CHudScoreboard::Draw( float fTime )
 	}
 
 	list_slot += 1.2f;
-	ypos = ROW_RANGE_MIN + ( list_slot * ROW_GAP );
+	ypos = TopLevelGap() + ( list_slot * ROW_GAP );
 	// xpos = NAME_RANGE_MIN + xpos_rel;
 	FillRGBA( xpos - 4, ypos, FAR_RIGHT -2, 1, 255, 140, 0, 255 );  // draw the seperator line
 
@@ -188,10 +200,10 @@ int CHudScoreboard::Draw( float fTime )
 		// draw out the best team
 		team_info_t *team_info = &g_TeamInfo[best_team];
 
-		ypos = ROW_RANGE_MIN + ( list_slot * ROW_GAP );
+		ypos = TopLevelGap() + ( list_slot * ROW_GAP );
 
 		// check we haven't drawn too far down
-		if( ypos > ROW_RANGE_MAX )  // don't draw to close to the lower border
+		if( ypos > ScoreboardHeight() )  // don't draw to close to the lower border
 			break;
 
 		xpos = NAME_RANGE_MIN + xpos_rel;
@@ -313,10 +325,10 @@ int CHudScoreboard::DrawPlayers( int xpos_rel, float list_slot, int nameoffset, 
 		// draw out the best player
 		hud_player_info_t *pl_info = &g_PlayerInfoList[best_player];
 
-		int ypos = ROW_RANGE_MIN + ( list_slot * ROW_GAP );
+		int ypos = TopLevelGap() + ( list_slot * ROW_GAP );
 
 		// check we haven't drawn too far down
-		if( ypos > ROW_RANGE_MAX )  // don't draw to close to the lower border
+		if( ypos > ScoreboardHeight() )  // don't draw to close to the lower border
 			break;
 
 		int xpos = NAME_RANGE_MIN + xpos_rel;


### PR DESCRIPTION
Currently the spectator UI borders obscure the non-vgui scoreboard

<img width="1600" height="900" alt="crossfire0001" src="https://github.com/user-attachments/assets/45422ff7-2351-4fc1-b401-f9f04399171a" />
